### PR TITLE
Automatically deploy releases and prereleases

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,53 @@
+name: Deploy
+
+on:
+  push:
+    tags:
+    - "*"
+
+env:
+  ENVIRONMENT: prod
+  OPENSHIFT_API: https://api.c-appuio-cloudscale-lpg-1.appuio.cloud:6443
+  HELM_RELEASE_NAME: odootools
+
+jobs:
+  helm:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup helmfile
+      uses: mamezou-tech/setup-helmfile@v0.8.0
+      with:
+        helm-version: v3.7.1
+        helmfile-version: v0.142.0
+        install-kubectl: false
+
+    - name: Install CLI tools from OpenShift Mirror
+      uses: redhat-actions/openshift-tools-installer@v1
+      with:
+        oc: "4"
+
+    - name: Set environment for release candidates
+      run: |
+        echo "ENVIRONMENT=preview" >> $GITHUB_ENV
+        echo "HELM_RELEASE_NAME=${GITHUB_REF##*-}" >> $GITHUB_ENV
+      if: "${{ contains(github.ref, '-rc') }}"
+
+    - name: Authenticate and set context
+      uses: redhat-actions/oc-login@v1
+      with:
+        openshift_server_url: ${{ env.OPENSHIFT_API }}
+        openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
+        namespace: odootools-${{ env.ENVIRONMENT }}
+        # We don't have a LE cert yet
+        insecure_skip_tls_verify: true
+
+    - name: Deploy app
+      run: helmfile -f envs/helmfile.yaml -e ${{ env.ENVIRONMENT }} apply
+      env:
+        HELM_RELEASE_NAME: ${{ env.HELM_RELEASE_NAME }}
+        IMG_TAG: ${{ github.ref }}
+        ODOO_DB: ${{ secrets.ODOO_DB }}
+        ODOO_URL: ${{ secrets.ODOO_URL }}
+        SECRET_KEY: ${{ secrets.SECRET_KEY }}

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
 [![GitHub downloads](https://img.shields.io/github/downloads/vshn/odootools/total)][releases]
 [![License](https://img.shields.io/github/license/vshn/odootools)][license]
 
+[build]: https://github.com/vshn/odootools/actions?query=workflow%3ATest
+[releases]: https://github.com/vshn/odootools/releases
+[license]: https://github.com/vshn/odootools/blob/master/LICENSE
+[codeclimate]: https://codeclimate.com/github/vshn/odootools
+
 # odootools
 
 odootools is a small tool that allows you to calculate overtime based on your attendances.
@@ -22,13 +27,29 @@ export ODOO_URL=https://...
 export ODOO_DB=...
 ```
 
-You can run the operator in different ways:
+You can run the tool in different ways:
 
 1. using `make run` (uses `go run`).
 2. using `make run.docker` (uses `docker run`)
 3. using a configuration of your favorite IDE
 
-[build]: https://github.com/vshn/odootools/actions?query=workflow%3ATest
-[releases]: https://github.com/vshn/odootools/releases
-[license]: https://github.com/vshn/odootools/blob/master/LICENSE
-[codeclimate]: https://codeclimate.com/github/vshn/odootools
+### Deploy to OpenShift
+
+Setup the project and deploy user
+
+```bash
+oc new-project odootools-preview
+oc new-project odootools-prod
+
+ns=odootools-prod
+sa=odootools-deployer
+
+oc -n $ns create sa $sa
+
+# Allow the deployer user to manage deployments in preview namespace
+oc -n $ns policy add-role-to-user admin -z $sa --rolebinding-name admin
+oc -n odootools-preview patch rolebinding admin --type='json' -p='[{"op": "replace", "path": "/subjects/1/namespace", "value":"'$ns'"}]'
+
+# Get SA token
+oc -n $ns sa get-token $sa
+```

--- a/envs/helmfile.yaml
+++ b/envs/helmfile.yaml
@@ -1,19 +1,23 @@
 environments:
-  default: {}
   prod: {}
+  preview: {}
 
 helmDefaults:
   historyMax: 3
 
 releases:
-  - name: odootools
-    namespace: odootools-prod
+  - name: {{ env "HELM_RELEASE_NAME" | default "odootools" }}
+    namespace: odootools-{{ .Environment.Name }}
     chart: ../chart
+    createNamespace: false
     missingFileHandler: Warn
     values:
       - {{ .Environment.Name }}.yaml
+      - image:
+          tag: {{ trimPrefix "refs/tags/" (requiredEnv "IMG_TAG") }}
       - odootools:
           secretEnvs:
             ODOO_URL: {{ requiredEnv "ODOO_URL" }}
             ODOO_DB: {{ requiredEnv "ODOO_DB" }}
             SECRET_KEY: {{ requiredEnv "SECRET_KEY" }}
+      - fullnameOverride: {{ env "HELM_RELEASE_NAME" | default "odootools" }}

--- a/envs/preview.yaml
+++ b/envs/preview.yaml
@@ -1,0 +1,2 @@
+route:
+  enabled: true

--- a/envs/prod.yaml
+++ b/envs/prod.yaml
@@ -1,0 +1,11 @@
+ingress:
+  enabled: true
+  hosts:
+    - host: odootools.vshn.net
+      paths:
+        - path: /
+          pathType: Exact
+  tls:
+    - secretName: odootools-tls
+      hosts:
+        - odootools.vshn.net

--- a/envs/prod.yaml
+++ b/envs/prod.yaml
@@ -1,2 +1,0 @@
-image:
-  tag: v0.2.0-rc1


### PR DESCRIPTION
## Summary

* Adds GH workflow that automatically runs `helmfile apply` for `v1.2.3` tags and preseleases `v1.2.3-rc1`

## Checklist


- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
