### PR TITLE
Fix redirect after login

### DIFF
--- a/pkg/web/session_handlers.go
+++ b/pkg/web/session_handlers.go
@@ -58,7 +58,7 @@ func (s Server) Login() http.Handler {
 			HttpOnly: true,
 			Secure:   true,
 		})
-		http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
+		http.Redirect(w, r, "/", http.StatusFound)
 	})
 }
 

--- a/test/session_test.go
+++ b/test/session_test.go
@@ -85,8 +85,8 @@ func TestLoginSuccess(t *testing.T) {
 	res := httptest.NewRecorder()
 	newServer(odooMock.URL).ServeHTTP(res, req)
 
-	is.Equal(res.Code, http.StatusTemporaryRedirect) // HTTP status
-	is.Equal(res.Header().Get("Location"), "/")      // Location header
+	is.Equal(res.Code, http.StatusFound)        // HTTP status
+	is.Equal(res.Header().Get("Location"), "/") // Location header
 
 	is.Equal(1, len(res.Result().Cookies())) // number of cookies
 	c := res.Result().Cookies()[0]


### PR DESCRIPTION
## Summary

The redirect caused the browser to be redirected to '/', but they were issueing POST requests instead of GET.

## Checklist


- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
