### PR TITLE
Remove check for attendance access for other users

### DIFF
--- a/pkg/odoo/employee.go
+++ b/pkg/odoo/employee.go
@@ -7,8 +7,6 @@ import (
 type Employee struct {
 	ID   int    `json:"id"`
 	Name string `json:"name"`
-	// AttendanceAccess returns true if the requesting user id has access to read attendances of this employee.
-	AttendanceAccess bool `json:"attendance_access"`
 }
 
 // SearchEmployee searches for an Employee with the given searchString in the Employee.Name.
@@ -53,7 +51,7 @@ func (c *Client) FetchEmployee(sid string, userId int) (*Employee, error) {
 	body, err := NewJsonRpcRequest(&ReadModelRequest{
 		Model:  "hr.employee",
 		Domain: []Filter{[]interface{}{"user_id", "=", userId}},
-		Fields: []string{"name", "attendance_access"},
+		Fields: []string{"name"},
 		Limit:  0,
 		Offset: 0,
 	}).Encode()

--- a/pkg/web/attendance_handlers.go
+++ b/pkg/web/attendance_handlers.go
@@ -40,10 +40,6 @@ func (s Server) OvertimeReport() http.Handler {
 				view.ShowError(w, fmt.Errorf("no user matching '%s' found", searchUser))
 				return
 			}
-			if !e.AttendanceAccess {
-				view.ShowError(w, fmt.Errorf("you don't have access to read attendances of '%s'", e.Name))
-				return
-			}
 			employee = e
 		} else {
 			e, err := s.odoo.FetchEmployee(session.ID, session.UID)


### PR DESCRIPTION
## Summary

The field returned by the employee query didn't have the desired effect.
So we'll just try to fetch them anyway.
It's a step backwards in UX but I couldn't quickly figure how to check permissions.


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
