### PR TITLE
Localize time zones when calculating overtime

### DIFF
--- a/pkg/odoo/contract.go
+++ b/pkg/odoo/contract.go
@@ -8,12 +8,17 @@ import (
 type ContractList []Contract
 
 type Contract struct {
-	ID              float64          `json:"id"`
-	Start           *Date            `json:"date_start"`
+	ID float64 `json:"id"`
+	// Start is the first day of the contract in UTC.
+	Start *Date `json:"date_start"`
+	// Start is the last day of the contract in UTC.
+	// It is nil or Zero if the contract hasn't ended yet.
 	End             *Date            `json:"date_end"`
 	WorkingSchedule *WorkingSchedule `json:"working_hours"`
 }
 
+// GetFTERatioForDay returns the workload ratio that is active for the given day.
+// All involved dates are expected to be in UTC.
 func (l ContractList) GetFTERatioForDay(day Date) (float64, error) {
 	date := day.ToTime()
 	for _, contract := range l {

--- a/pkg/timesheet/dailysummary.go
+++ b/pkg/timesheet/dailysummary.go
@@ -7,6 +7,7 @@ import (
 )
 
 type DailySummary struct {
+	// Date is the localized date of the summary.
 	Date     time.Time
 	Blocks   []AttendanceBlock
 	Absences []AbsenceBlock
@@ -15,6 +16,7 @@ type DailySummary struct {
 
 // NewDailySummary creates a new instance.
 // The fteRatio is the percentage (input a value between 0..1) of the employee and is used to calculate the daily maximum hours an employee should work.
+// Date is expected to be in a localized timezone.
 func NewDailySummary(fteRatio float64, date time.Time) *DailySummary {
 	return &DailySummary{
 		FTERatio: fteRatio,

--- a/pkg/timesheet/dailysummary_test.go
+++ b/pkg/timesheet/dailysummary_test.go
@@ -173,3 +173,33 @@ func TestDailySummary_CalculateDailyMaxHours(t *testing.T) {
 		})
 	}
 }
+
+func Test_findDailySummaryByDate(t *testing.T) {
+	tests := map[string]struct {
+		givenDailies    []*DailySummary
+		givenDate       time.Time
+		expectedSummary *DailySummary
+	}{
+		"GivenDailies_WhenDateMatches_ThenReturnDaily": {
+			givenDailies: []*DailySummary{
+				NewDailySummary(1, *date(t, "2021-02-03")),
+			},
+			givenDate:       *date(t, "2021-02-03"),
+			expectedSummary: NewDailySummary(1, *date(t, "2021-02-03")),
+		},
+		"GivenDailies_WhenDateMatchesInUTC_ThenReturnDaily": {
+			givenDailies: []*DailySummary{
+				NewDailySummary(1, date(t, "2021-02-04").UTC()),
+				NewDailySummary(1, date(t, "2021-02-03").UTC()),
+			},
+			givenDate:       newDateTime(t, "2021-02-03 23:30").ToTime(),
+			expectedSummary: NewDailySummary(1, date(t, "2021-02-03").UTC()),
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, _ := findDailySummaryByDate(tt.givenDailies, tt.givenDate)
+			assert.Equal(t, tt.expectedSummary, result)
+		})
+	}
+}

--- a/pkg/web/report_handler.go
+++ b/pkg/web/report_handler.go
@@ -68,7 +68,9 @@ func (s Server) OvertimeReport() http.Handler {
 			return
 		}
 
-		reporter := timesheet.NewReporter(attendances, leaves, employee, contracts).SetMonth(input.Year, input.Month)
+		reporter := timesheet.NewReporter(attendances, leaves, employee, contracts).
+			SetMonth(input.Year, input.Month).
+			SetTimeZone("Europe/Zurich") // hardcoded for now
 		report := reporter.CalculateReport()
 		view.ShowAttendanceReport(w, report)
 	})


### PR DESCRIPTION
## Summary

The times from Odoo are returned in UTC.
However, there are cases where some overtime hours are moved to the next date between 00:00 and 01:00 (resp. 02:00 in summer).
This change should fix the calculation to Europe/Zurich timezone

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update the documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
