### PR TITLE
Add navigational links to switch between months

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,6 @@
 
 ## Checklist
 
-- [ ] Keep pull requests small so they can be easily reviewed.
 - [ ] Categorize the PR by setting a good title and adding one of the labels:
       `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
       as they show up in the changelog

--- a/pkg/timesheet/report.go
+++ b/pkg/timesheet/report.go
@@ -55,6 +55,8 @@ type Report struct {
 	DailySummaries []*DailySummary
 	Summary        Summary
 	Employee       *odoo.Employee
+	Year           int
+	Month          int
 }
 
 type Reporter struct {
@@ -112,6 +114,8 @@ func (r *Reporter) CalculateReport() Report {
 		DailySummaries: dailySummaries,
 		Summary:        summary,
 		Employee:       r.employee,
+		Year:           r.year,
+		Month:          r.month,
 	}
 }
 

--- a/pkg/web/views/overtimereport_view.go
+++ b/pkg/web/views/overtimereport_view.go
@@ -75,13 +75,32 @@ func (v *OvertimeReportView) prepareValues(report timesheet.Report) Values {
 		}
 		formatted = append(formatted, v.formatDailySummary(summary))
 	}
+	nextYear, nextMonth := getNextMonth(report)
+	prevYear, prevMonth := getPreviousMonth(report)
 	return Values{
 		"Attendances": formatted,
 		"Summary":     v.formatSummary(report.Summary),
 		"Nav": Values{
-			"LoggedIn":   true,
-			"ActiveView": v.template,
+			"LoggedIn":          true,
+			"ActiveView":        v.template,
+			"CurrentMonthLink":  fmt.Sprintf("/report/%d/%d/%02d", report.Employee.ID, time.Now().Year(), time.Now().Month()),
+			"NextMonthLink":     fmt.Sprintf("/report/%d/%d/%02d", report.Employee.ID, nextYear, nextMonth),
+			"PreviousMonthLink": fmt.Sprintf("/report/%d/%d/%02d", report.Employee.ID, prevYear, prevMonth),
 		},
 		"Username": report.Employee.Name,
 	}
+}
+
+func getNextMonth(r timesheet.Report) (int, int) {
+	if r.Month >= 12 {
+		return r.Year + 1, 1
+	}
+	return r.Year, r.Month + 1
+}
+
+func getPreviousMonth(r timesheet.Report) (int, int) {
+	if r.Month <= 1 {
+		return r.Year - 1, 12
+	}
+	return r.Year, r.Month - 1
 }

--- a/templates/overtimereport.html
+++ b/templates/overtimereport.html
@@ -3,6 +3,11 @@
 {{ with .Error }}
 <div class="alert alert-warning" role="alert">{{ . }}</div>
 {{ end }}
+<p>
+    <a href="{{ .Nav.PreviousMonthLink }}" class="btn btn-secondary">Previous</a>
+    <a href="{{ .Nav.CurrentMonthLink }}" class="btn btn-primary">Current</a>
+    <a href="{{ .Nav.NextMonthLink }}" class="btn btn-secondary">Next</a>
+</p>
 <table class="table table-hover table-sm">
     <thead>
     <tr>


### PR DESCRIPTION
## Summary

* Adds "Previous", "Current" and "Next" links to the top, allowing navigating between months.
* Closes #22 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
