### PR TITLE
Fix access error when trying to retrieve Employee

### DIFF
--- a/pkg/odoo/employee.go
+++ b/pkg/odoo/employee.go
@@ -33,7 +33,7 @@ func (c *Client) readEmployee(sid string, filters []Filter) (*Employee, error) {
 	body, err := NewJsonRpcRequest(&ReadModelRequest{
 		Model:  "hr.employee",
 		Domain: filters,
-		//Fields: []string{"name"},
+		Fields: []string{"name"},
 		Limit:  0,
 		Offset: 0,
 	}).Encode()


### PR DESCRIPTION
## Summary

Without the filtering the fields, all fields are returned.
But some fields returned are behind access control and then all fields get denied

This change reverts commenting out something that was part of #33 while testing

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update the documentation.
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
