### PR TITLE
Fix calculation around attendances after starting a new month

### DIFF
--- a/pkg/odoo/attendance.go
+++ b/pkg/odoo/attendance.go
@@ -2,6 +2,7 @@ package odoo
 
 import (
 	"fmt"
+	"time"
 )
 
 type Attendance struct {
@@ -24,11 +25,11 @@ func (c Client) FetchAllAttendances(sid string, employeeID int) ([]Attendance, e
 	return c.fetchAttendances(sid, []Filter{[]interface{}{"employee_id", "=", employeeID}})
 }
 
-func (c Client) FetchAttendancesBetweenDates(sid string, employeeID int, begin, end Date) ([]Attendance, error) {
+func (c Client) FetchAttendancesBetweenDates(sid string, employeeID int, begin, end time.Time) ([]Attendance, error) {
 	return c.fetchAttendances(sid, []Filter{
 		[]interface{}{"employee_id", "=", employeeID},
-		[]string{"name", ">=", begin.ToTime().Format(DateFormat)},
-		[]string{"name", "<=", end.ToTime().Format(DateFormat)},
+		[]string{"name", ">=", begin.Format(DateFormat)},
+		[]string{"name", "<=", end.Format(DateFormat)},
 	})
 }
 

--- a/pkg/odoo/leave.go
+++ b/pkg/odoo/leave.go
@@ -36,9 +36,9 @@ func (c *Client) FetchAllLeaves(sid string, employeeID int) ([]Leave, error) {
 	})
 }
 
-func (c *Client) FetchLeavesBetweenDates(sid string, employeeID int, begin, end Date) ([]Leave, error) {
-	beginStr := begin.ToTime().Format(DateFormat)
-	endStr := end.ToTime().Format(DateFormat)
+func (c *Client) FetchLeavesBetweenDates(sid string, employeeID int, begin, end time.Time) ([]Leave, error) {
+	beginStr := begin.Format(DateFormat)
+	endStr := end.Format(DateFormat)
 	return c.readLeaves(sid, []Filter{
 		[]string{"type", "=", "remove"}, // Only return used leaves. With type = "add" we would get leaves that add days to holiday budget
 		[]interface{}{"employee_id", "=", employeeID},

--- a/pkg/timesheet/report.go
+++ b/pkg/timesheet/report.go
@@ -207,7 +207,7 @@ func sortAttendances(filtered []odoo.Attendance) {
 func (r *Reporter) filterAttendancesInMonth() []odoo.Attendance {
 	filteredAttendances := make([]odoo.Attendance, 0)
 	for _, attendance := range r.attendances {
-		if attendance.DateTime.IsWithinMonth(r.year, r.month) {
+		if attendance.DateTime.WithLocation(r.timezone).IsWithinMonth(r.year, r.month) {
 			filteredAttendances = append(filteredAttendances, attendance)
 		}
 	}
@@ -219,7 +219,7 @@ func (r *Reporter) filterLeavesInMonth() []odoo.Leave {
 	for _, leave := range r.leaves {
 		splits := leave.SplitByDay()
 		for _, split := range splits {
-			date := split.DateFrom
+			date := split.DateFrom.WithLocation(r.timezone)
 			if date.IsWithinMonth(r.year, r.month) && date.ToTime().Weekday() != time.Sunday && date.ToTime().Weekday() != time.Saturday {
 				filteredLeaves = append(filteredLeaves, split)
 			}

--- a/pkg/web/report_handler.go
+++ b/pkg/web/report_handler.go
@@ -82,8 +82,10 @@ func (s Server) OvertimeReport() http.Handler {
 			return
 		}
 
-		begin := odoo.Date(time.Date(input.Year, time.Month(input.Month), 1, 0, 0, 0, 0, time.UTC))
-		end := odoo.Date(begin.ToTime().AddDate(0, 1, 0))
+		firstDay := time.Date(input.Year, time.Month(input.Month), 1, 0, 0, 0, 0, time.UTC)
+		// Let's get attendances within a month with +- 1 day to respect localized dates and filter them later.
+		begin := firstDay.AddDate(0, 0, -1)
+		end := firstDay.AddDate(0, 1, 0)
 
 		contracts, err := s.odoo.FetchAllContracts(session.ID, employee.ID)
 		if err != nil {


### PR DESCRIPTION
## Summary

* Fixes an issue where not attendances from previous month are missing due to different timezones.
* Fixes calculation where an attendances has the same timestamp as the first second of the same day.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
