### PR TITLE
Don't run preview deployments when updating dependencies

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -14,6 +14,7 @@ env:
 jobs:
   install:
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependency') }}
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/destroy-preview.yaml
+++ b/.github/workflows/destroy-preview.yaml
@@ -15,6 +15,7 @@ env:
 jobs:
   uninstall:
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependency') }}
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
## Summary

* Ignores preview deployments when PRs have the `dependency` label. This will avoid open Renovate PRs to consume unnecessary resources, especially over long time.
* follow-up of #37 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
