### PR TITLE
Display new overtime balance in overtime report

### DIFF
--- a/pkg/odoo/payslip.go
+++ b/pkg/odoo/payslip.go
@@ -1,0 +1,101 @@
+package odoo
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+type Payslip struct {
+	ID       int         `json:"id"`
+	Name     string      `json:"name"`
+	Overtime interface{} `json:"x_overtime"`
+	DateFrom Date        `json:"date_from"`
+	DateTo   Date        `json:"date_to"`
+}
+
+func (c Client) FetchPayslipOfLastMonth(sid string, employeeID int, lastDayOfMonth time.Time) (*Payslip, error) {
+	payslips, err := c.readPayslips(sid, []Filter{
+		[]interface{}{"employee_id", "=", employeeID},
+		[]string{"date_to", "<=", lastDayOfMonth.Format(DateFormat)},
+		[]string{"date_from", ">=", lastDayOfMonth.AddDate(0, -1, -1).Format(DateFormat)},
+	})
+	for _, payslip := range payslips {
+		if strings.Contains(payslip.Name, "Pikett") {
+			continue
+		}
+		if strings.Contains(payslip.Name, "Salary") {
+			return &payslip, nil
+		}
+	}
+	return nil, err
+}
+
+func (c Client) readPayslips(sid string, domainFilters []Filter) ([]Payslip, error) {
+	// Prepare "search contract" request
+	body, err := NewJsonRpcRequest(&ReadModelRequest{
+		Model:  "hr.payslip",
+		Domain: domainFilters,
+		Fields: []string{"date_from", "date_to", "x_overtime", "name"},
+	}).Encode()
+	if err != nil {
+		return nil, fmt.Errorf("encoding request: %w", err)
+	}
+
+	res, err := c.makeRequest(sid, body)
+	if err != nil {
+		return nil, err
+	}
+
+	type readResult struct {
+		Length  int       `json:"length,omitempty"`
+		Records []Payslip `json:"records,omitempty"`
+	}
+	result := &readResult{}
+	if err := c.unmarshalResponse(res.Body, result); err != nil {
+		return nil, err
+	}
+	return result.Records, nil
+}
+
+// GetOvertime returns the plain field value as string.
+func (p Payslip) GetOvertime() string {
+	if _, ok := p.Overtime.(bool); ok {
+		return ""
+	}
+	return p.Overtime.(string)
+}
+
+const clockLayout = "15:04:05"
+
+var clockZero, _ = time.Parse(clockLayout, "00:00:00")
+
+// colonFormatRegex searches for string reference that has somewhere a pattern like '123:45' or '123:45:54'
+// A match will be divided into subgroups, e.g. '123' for hours, '45' for minutes, '54' for seconds.
+// The hours group can have a dash in front of the number to indicate negative hours.
+var colonFormatRegex = regexp.MustCompile(".*?((-?\\d+):(\\d{2})(?::?(\\d{2}))?).*")
+
+// ParseOvertime tries to parse the currently inconsistently-formatted custom field to a duration.
+// If the field is empty, 0 is returned without error.
+// It parses the following formats:
+//  * hhh:mm (e.g. '15:54')
+//  * hhh:mm:ss (e.g. '153:54:45')
+//  * {1,2}d{1,2}h (e.g. '15d54m')
+func (p Payslip) ParseOvertime() (time.Duration, error) {
+	raw := p.GetOvertime()
+	if raw == "" {
+		return 0, nil
+	}
+	if matches := colonFormatRegex.FindStringSubmatch(raw); matches != nil {
+		rawHours := matches[2]
+		rawMinutes := matches[3]
+		rawSeconds := matches[4]
+		if rawSeconds == "" {
+			rawSeconds = "0"
+		}
+		t, err := time.ParseDuration(fmt.Sprintf("%sh%sm%ss", rawHours, rawMinutes, rawSeconds))
+		return t, err
+	}
+	return 0, fmt.Errorf("format not parseable: %s", raw)
+}

--- a/pkg/odoo/payslip_test.go
+++ b/pkg/odoo/payslip_test.go
@@ -1,0 +1,55 @@
+package odoo
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPayslip_ParseOvertime(t *testing.T) {
+	tests := map[string]struct {
+		givenOvertime    string
+		expectedOvertime time.Duration
+		expectedError    string
+	}{
+		"GivenEmptyField_ThenExpectZero": {
+			givenOvertime: "",
+		},
+		"GivenField_WhenNoFormatRecognized_ThenExpectError": {
+			givenOvertime: "not-properly-formatted",
+			expectedError: "format not parseable: not-properly-formatted",
+		},
+		"GivenField_WhenColonFormatWithoutSeconds_ThenExpectParsedHours": {
+			givenOvertime:    "Currently 143:34 (including holidays)\n",
+			expectedOvertime: newDuration(t, "143h34m"),
+		},
+		"GivenField_WhenColonFormatWithSeconds_ThenExpectParsedHours": {
+			givenOvertime:    "Currently 143:34:43 (including holidays)\n",
+			expectedOvertime: newDuration(t, "143h34m43s"),
+		},
+		"GivenField_WhenColonFormatNegativeNumber_ThenExpectNegativeHours": {
+			givenOvertime:    "-143:34:43 (including holidays)\n",
+			expectedOvertime: newDuration(t, "-143h34m43s"),
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			p := Payslip{Overtime: tt.givenOvertime}
+			result, err := p.ParseOvertime()
+			if tt.expectedError != "" {
+				assert.EqualError(t, err, tt.expectedError)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedOvertime, result)
+		})
+	}
+}
+
+func newDuration(t *testing.T, s string) time.Duration {
+	d, err := time.ParseDuration(s)
+	require.NoError(t, err)
+	return d
+}

--- a/pkg/web/overtimereport/overtimereport_request.go
+++ b/pkg/web/overtimereport/overtimereport_request.go
@@ -8,19 +8,17 @@ import (
 )
 
 type ReportRequest struct {
-	Year              int    `param:"year"`
-	Month             int    `param:"month"`
+	Year              int    `param:"year" form:"year"`
+	Month             int    `param:"month" form:"month"`
 	SearchUser        string `form:"username"`
 	SearchUserEnabled bool
 	EmployeeID        int `param:"employee"`
 }
 
 func (i *ReportRequest) FromRequest(e echo.Context) error {
-	err := e.Bind(i)
-	if err != nil {
+	if err := e.Bind(i); err != nil {
 		return err
 	}
-
 	i.SearchUserEnabled = e.FormValue("userscope") == "user-foreign-radio"
 	i.SearchUser = html.EscapeString(i.SearchUser)
 

--- a/templates/overtimereport.html
+++ b/templates/overtimereport.html
@@ -40,8 +40,8 @@
         <th scope="col"></th>
         <th scope="col">Total Leaves</th>
         <th scope="col"></th>
-        <th scope="col"></th>
         <th scope="col">Total Overtime</th>
+        <th scope="col">New Balance</th>
     </tr>
     <tr>
         <td></td>
@@ -49,8 +49,8 @@
         <td></td>
         <td>{{ .Summary.TotalLeaves }}</td>
         <td></td>
-        <td></td>
         <td>{{ .Summary.TotalOvertime }}</td>
+        <td>{{ if .Summary.PayslipError }}{{ .Summary.PayslipError }}{{ else }}{{ .Summary.NewOvertimeBalance }}{{ end }}</td>
     </tr>
     </tfoot>
 </table>


### PR DESCRIPTION
## Summary

* Closes #26 
* The overtime report now adds the overtime delta with the overtime information that is stored in the last payslip to display the new balance.

NOTE: The "overtime" field is a custom field added to Payslips. This isn't the case since the beginning, so very old overtime reports will not show the balance if that field is missing.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update the documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
