### PR TITLE
Fix holiday summary

### DIFF
--- a/pkg/timesheet/dailysummary.go
+++ b/pkg/timesheet/dailysummary.go
@@ -130,6 +130,17 @@ func (s *DailySummary) HasAbsences() bool {
 	return len(s.Absences) != 0
 }
 
+// IsHoliday returns true if there is any paid leave on that day.
+// However, if the holiday falls on a weekend, the day is not counted.
+func (s *DailySummary) IsHoliday() bool {
+	for _, absence := range s.Absences {
+		if absence.Reason != TypeUnpaid {
+			return !s.IsWeekend()
+		}
+	}
+	return false
+}
+
 // IsWeekend returns true if the date falls on a Saturday or Sunday.
 func (s *DailySummary) IsWeekend() bool {
 	return s.Date.Weekday() == time.Saturday || s.Date.Weekday() == time.Sunday

--- a/pkg/timesheet/dailysummary_test.go
+++ b/pkg/timesheet/dailysummary_test.go
@@ -203,3 +203,39 @@ func Test_findDailySummaryByDate(t *testing.T) {
 		})
 	}
 }
+
+func TestDailySummary_IsHoliday(t *testing.T) {
+	tests := map[string]struct {
+		givenDay        *DailySummary
+		expectedHoliday bool
+	}{
+		"GivenDailyWithoutAbsences_ThenReturnFalse": {
+			givenDay: &DailySummary{Date: *date(t, "2021-02-04")},
+		},
+		"GivenDailyWithAbsence_WhenPublicHoliday_ThenReturnTrue": {
+			givenDay: &DailySummary{
+				Date:     *date(t, "2021-02-04"),
+				Absences: []AbsenceBlock{{Reason: TypePublicHoliday}},
+			},
+			expectedHoliday: true,
+		},
+		"GivenDailyWithAbsence_WhenPublicHolidayOnWeekend_ThenReturnFalse": {
+			givenDay: &DailySummary{
+				Date:     *date(t, "2021-02-06"),
+				Absences: []AbsenceBlock{{Reason: TypePublicHoliday}},
+			},
+		},
+		"GivenDailyWithAbsence_WhenUnpaid_ThenReturnFalse": {
+			givenDay: &DailySummary{
+				Date:     *date(t, "2021-02-04"),
+				Absences: []AbsenceBlock{{Reason: TypeUnpaid}},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := tt.givenDay.IsHoliday()
+			assert.Equal(t, tt.expectedHoliday, result)
+		})
+	}
+}

--- a/pkg/timesheet/report.go
+++ b/pkg/timesheet/report.go
@@ -48,9 +48,11 @@ type AbsenceBlock struct {
 
 type Summary struct {
 	TotalOvertime    time.Duration
-	TotalLeave       time.Duration
 	TotalExcusedTime time.Duration
 	TotalWorkedTime  time.Duration
+	// TotalLeave is the amount of paid leave days.
+	// This value respects FTE ratio, e.g. in a 50% ratio a public holiday is still counted as '1d'.
+	TotalLeave float64
 }
 
 type MonthlyReport struct {
@@ -110,9 +112,11 @@ func (r *ReportBuilder) CalculateMonthlyReport() MonthlyReport {
 	summary := Summary{}
 	for _, dailySummary := range dailySummaries {
 		summary.TotalOvertime += dailySummary.CalculateOvertime()
-		summary.TotalLeave += dailySummary.CalculateAbsenceTime()
 		summary.TotalExcusedTime += dailySummary.CalculateExcusedTime()
 		summary.TotalWorkedTime += dailySummary.CalculateWorkingTime()
+		if dailySummary.IsHoliday() {
+			summary.TotalLeave += 1
+		}
 	}
 	return MonthlyReport{
 		DailySummaries: dailySummaries,

--- a/pkg/timesheet/report_test.go
+++ b/pkg/timesheet/report_test.go
@@ -152,53 +152,17 @@ func TestReporter_prepareWorkDays(t *testing.T) {
 		expectedDays []*DailySummary
 		nowF         func() time.Time
 	}{
-		"GivenFullMonthInThePast_ThenReturnOnlyWorkingDays": {
-			givenYear:  2021,
-			givenMonth: 5,
-			expectedDays: []*DailySummary{
-				{Date: *date(t, "2021-05-01")},
-				{Date: *date(t, "2021-05-02")},
-				{Date: *date(t, "2021-05-03")},
-				{Date: *date(t, "2021-05-04")},
-				{Date: *date(t, "2021-05-05")},
-				{Date: *date(t, "2021-05-06")},
-				{Date: *date(t, "2021-05-07")},
-				{Date: *date(t, "2021-05-08")},
-				{Date: *date(t, "2021-05-09")},
-				{Date: *date(t, "2021-05-10")},
-				{Date: *date(t, "2021-05-11")},
-				{Date: *date(t, "2021-05-12")},
-				{Date: *date(t, "2021-05-13")},
-				{Date: *date(t, "2021-05-14")},
-				{Date: *date(t, "2021-05-15")},
-				{Date: *date(t, "2021-05-16")},
-				{Date: *date(t, "2021-05-17")},
-				{Date: *date(t, "2021-05-18")},
-				{Date: *date(t, "2021-05-19")},
-				{Date: *date(t, "2021-05-20")},
-				{Date: *date(t, "2021-05-21")},
-				{Date: *date(t, "2021-05-22")},
-				{Date: *date(t, "2021-05-23")},
-				{Date: *date(t, "2021-05-24")},
-				{Date: *date(t, "2021-05-25")},
-				{Date: *date(t, "2021-05-26")},
-				{Date: *date(t, "2021-05-27")},
-				{Date: *date(t, "2021-05-28")},
-				{Date: *date(t, "2021-05-29")},
-				{Date: *date(t, "2021-05-30")},
-				{Date: *date(t, "2021-05-31")},
-			},
+		"GivenFullMonthInThePast_ThenReturnAllDays": {
+			givenYear:    2021,
+			givenMonth:   5,
+			expectedDays: generateMonth(t, 2021, 5, 31),
 		},
 		"GivenCurrentMonth_ThenReturnNoMoreThanToday": {
-			givenYear:  2021,
-			givenMonth: 3,
-			expectedDays: []*DailySummary{
-				{Date: *date(t, "2021-03-01")},
-				{Date: *date(t, "2021-03-02")},
-				{Date: *date(t, "2021-03-03")},
-			},
+			givenYear:    2021,
+			givenMonth:   3,
+			expectedDays: generateMonth(t, 2021, 3, 7),
 			nowF: func() time.Time {
-				return time.Unix(1614788672, 0) // Wednesday, March 3, 2021 4:24:32 PM
+				return time.Unix(1615113136, 0) // Sunday, March 7, 2021 10:32:16
 			},
 		},
 	}
@@ -225,4 +189,12 @@ func TestReporter_prepareWorkDays(t *testing.T) {
 			}
 		})
 	}
+}
+
+func generateMonth(t *testing.T, year, month, lastDay int) []*DailySummary {
+	days := make([]*DailySummary, lastDay)
+	for i := 0; i < lastDay; i++ {
+		days[i] = &DailySummary{Date: *date(t, fmt.Sprintf("%d-%02d-%02d", year, month, i+1))}
+	}
+	return days
 }

--- a/pkg/timesheet/yearly_report.go
+++ b/pkg/timesheet/yearly_report.go
@@ -17,7 +17,7 @@ type YearlySummary struct {
 	TotalOvertime time.Duration
 	TotalExcused  time.Duration
 	TotalWorked   time.Duration
-	TotalLeaves   time.Duration
+	TotalLeaves   float64
 }
 
 func (r *ReportBuilder) CalculateYearlyReport() YearlyReport {

--- a/pkg/web/overtimereport/monthlyreport_view.go
+++ b/pkg/web/overtimereport/monthlyreport_view.go
@@ -47,11 +47,14 @@ func formatDurationInHours(d time.Duration) string {
 	return fmt.Sprintf("%s%d:%02d", sign, h, m)
 }
 
+func formatFloat(v float64) string {
+	return strconv.FormatFloat(v, 'f', 1, 64)
+}
+
 func (v *reportView) formatMonthlySummary(s timesheet.Summary, payslip *odoo.Payslip) controller.Values {
 	val := controller.Values{
 		"TotalOvertime": formatDurationInHours(s.TotalOvertime),
-		// TODO: Might not be accurate for days before 2021
-		"TotalLeaves": fmt.Sprintf("%sd", strconv.FormatFloat(s.TotalLeave.Hours()/8, 'f', 0, 64)),
+		"TotalLeaves":   fmt.Sprintf("%sd", formatFloat(s.TotalLeave)),
 	}
 	if payslip == nil {
 		val["PayslipError"] = "No matching payslip found"

--- a/pkg/web/overtimereport/yearlyreport_view.go
+++ b/pkg/web/overtimereport/yearlyreport_view.go
@@ -2,7 +2,6 @@ package overtimereport
 
 import (
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/vshn/odootools/pkg/timesheet"
@@ -36,7 +35,7 @@ func (v *reportView) GetValuesForYearlyReport(report timesheet.YearlyReport) con
 func (v *reportView) formatMonthlySummaryForYearlyReport(s timesheet.MonthlyReport) controller.Values {
 	val := controller.Values{
 		"OvertimeHours":  formatDurationInHours(s.Summary.TotalOvertime),
-		"LeaveDays":      fmt.Sprintf("%sd", strconv.FormatFloat(s.Summary.TotalLeave.Hours()/8, 'f', 0, 64)),
+		"LeaveDays":      formatFloat(s.Summary.TotalLeave),
 		"ExcusedHours":   formatDurationInHours(s.Summary.TotalExcusedTime),
 		"WorkedHours":    formatDurationInHours(s.Summary.TotalWorkedTime),
 		"DetailViewLink": fmt.Sprintf("/report/%d/%d/%d", s.Employee.ID, s.Year, s.Month),
@@ -50,6 +49,6 @@ func (v *reportView) formatYearlySummary(summary timesheet.YearlySummary) contro
 		"TotalExcused":  formatDurationInHours(summary.TotalExcused),
 		"TotalWorked":   formatDurationInHours(summary.TotalWorked),
 		"TotalOvertime": formatDurationInHours(summary.TotalOvertime),
-		"TotalLeaves":   "not-implemented-yet",
+		"TotalLeaves":   formatFloat(summary.TotalLeaves),
 	}
 }


### PR DESCRIPTION
## Summary

* The exact leave duration is needed to calculate overtime, however for displaying leaves it was not human friendly and sometimes actually wrong.
* Now, the reports show "full days" since in Odoo, we can only register full leave days, not partial days.


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update the documentation.
- [x] Update tests.
- [x] Rebase after #47 

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
