### PR TITLE
Don't display months in yearly reports where contract didn't start

### DIFF
--- a/pkg/timesheet/yearly_report.go
+++ b/pkg/timesheet/yearly_report.go
@@ -22,11 +22,17 @@ type YearlySummary struct {
 
 func (r *ReportBuilder) CalculateYearlyReport() YearlyReport {
 	reports := make([]MonthlyReport, 0)
+
 	max := 12
 	if r.year >= now().Year() {
 		max = int(now().Month())
 	}
-	for _, month := range makeRange(1, max) {
+	min := 1
+	if startDate, found := r.getEarliestStartContractDate(); found && startDate.Year() == now().Year() && r.year == now().Year() {
+		min = int(startDate.Month())
+	}
+
+	for _, month := range makeRange(min, max) {
 		r.month = month
 		monthlyReport := r.CalculateMonthlyReport()
 		reports = append(reports, monthlyReport)
@@ -53,4 +59,15 @@ func makeRange(min, max int) []int {
 		a[i] = min + i
 	}
 	return a
+}
+
+func (r *ReportBuilder) getEarliestStartContractDate() (time.Time, bool) {
+	n := now()
+	start := n
+	for _, contract := range r.contracts {
+		if contract.Start.ToTime().Before(start) {
+			start = contract.Start.ToTime()
+		}
+	}
+	return start, start != n
 }

--- a/pkg/timesheet/yearly_report_test.go
+++ b/pkg/timesheet/yearly_report_test.go
@@ -1,0 +1,39 @@
+package timesheet
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vshn/odootools/pkg/odoo"
+)
+
+func TestReportBuilder_getEarliestStartContractDate(t *testing.T) {
+	tests := map[string]struct {
+		givenContracts odoo.ContractList
+		expectedDate   time.Time
+		expectedFound  bool
+	}{
+		"GivenNoContracts_ThenReturnFalse": {
+			givenContracts: nil,
+			expectedFound:  false,
+		},
+		"GivenContracts_WhenStartDateExists_ThenReturnTrue": {
+			givenContracts: odoo.ContractList{
+				odoo.Contract{Start: newDateTime(t, "2021-02-04 08:00")},
+			},
+			expectedDate:  newDateTime(t, "2021-02-04 08:00").ToTime(),
+			expectedFound: true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			r := NewReporter(nil, nil, nil, tt.givenContracts)
+			resultDate, found := r.getEarliestStartContractDate()
+			assert.Equal(t, tt.expectedFound, found)
+			if tt.expectedFound {
+				assert.Equal(t, tt.expectedDate, resultDate)
+			}
+		})
+	}
+}


### PR DESCRIPTION


## Summary

* For people that started in the middle of the current year the months are hidden and not calculated in the yearly report view

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update the documentation.
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
