### PR TITLE
Add year digits to monthly report links

### DIFF
--- a/pkg/web/overtimereport/yearlyreport_view.go
+++ b/pkg/web/overtimereport/yearlyreport_view.go
@@ -39,7 +39,7 @@ func (v *reportView) formatMonthlySummaryForYearlyReport(s timesheet.MonthlyRepo
 		"ExcusedHours":   formatDurationInHours(s.Summary.TotalExcusedTime),
 		"WorkedHours":    formatDurationInHours(s.Summary.TotalWorkedTime),
 		"DetailViewLink": fmt.Sprintf("/report/%d/%d/%d", s.Employee.ID, s.Year, s.Month),
-		"Name":           time.Month(s.Month).String(),
+		"Name":           fmt.Sprintf("%s %d", time.Month(s.Month), s.Year),
 	}
 	return val
 }


### PR DESCRIPTION
## Summary

* When browsing through yearly reports, it was only visible in the URL which year someone is looking at. This PR adds the year to the direct links for better UX

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
