### PR TITLE
Ensure `make run` can actually run odootools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ lint: fmt vet generate ## All-in-one linting
 run: export LISTEN_ADDRESS=localhost:4200
 run: export SECRET_KEY=$(LOCAL_SECRET_KEY)
 run: ## Run a local instance on localhost:4200
-	go run main.go web
+	go run . web
 
 run.docker: build.docker ## Run in docker on port 8080
 	docker run --rm -it --env "SECRET_KEY=$(LOCAL_SECRET_KEY)" --env ODOO_DB --env ODOO_URL --env "LISTEN_ADDRESS=:8080" --publish "8080:8080" $(CONTAINER_IMG) web


### PR DESCRIPTION
## Summary

The current make target only loaded `main.go` while some methods are in
other go files.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog