### PR TITLE
Tell units when it's not hours in yearly report

### DIFF
--- a/templates/overtimereport-yearly.html
+++ b/templates/overtimereport-yearly.html
@@ -22,7 +22,7 @@
     {{ range .MonthlyReports }}
     <tr>
         <td><a href="{{ .DetailViewLink }}">{{ .Name }}</a></td>
-        <td>{{ .LeaveDays }}</td>
+        <td>{{ .LeaveDays }}d</td>
         <td>{{ .ExcusedHours }}</td>
         <td>{{ .WorkedHours }}</td>
         <td>{{ .OvertimeHours }}</td>
@@ -39,7 +39,7 @@
     </tr>
     <tr>
         <td></td>
-        <td>{{ .Summary.TotalLeaves }}</td>
+        <td>{{ .Summary.TotalLeaves }}d</td>
         <td>{{ .Summary.TotalExcused }}</td>
         <td>{{ .Summary.TotalWorked }}</td>
         <td>{{ .Summary.TotalOvertime }}</td>


### PR DESCRIPTION
## Summary

This was not immediately obvious to me so I thought it won't hurt to make it obvious.

Brings the report in line with the monthly report.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
