### PR TITLE
Abort reporting with error when contracts cannot be accessed

### DIFF
--- a/pkg/timesheet/yearly_report.go
+++ b/pkg/timesheet/yearly_report.go
@@ -20,7 +20,7 @@ type YearlySummary struct {
 	TotalLeaves   float64
 }
 
-func (r *ReportBuilder) CalculateYearlyReport() YearlyReport {
+func (r *ReportBuilder) CalculateYearlyReport() (YearlyReport, error) {
 	reports := make([]MonthlyReport, 0)
 
 	max := 12
@@ -34,7 +34,10 @@ func (r *ReportBuilder) CalculateYearlyReport() YearlyReport {
 
 	for _, month := range makeRange(min, max) {
 		r.month = month
-		monthlyReport := r.CalculateMonthlyReport()
+		monthlyReport, err := r.CalculateMonthlyReport()
+		if err != nil {
+			return YearlyReport{}, err
+		}
 		reports = append(reports, monthlyReport)
 	}
 	yearlyReport := YearlyReport{
@@ -50,7 +53,7 @@ func (r *ReportBuilder) CalculateYearlyReport() YearlyReport {
 		summary.TotalLeaves += month.Summary.TotalLeave
 	}
 	yearlyReport.Summary = summary
-	return yearlyReport
+	return yearlyReport, nil
 }
 
 func makeRange(min, max int) []int {

--- a/pkg/web/overtimereport/overtimereport_controller.go
+++ b/pkg/web/overtimereport/overtimereport_controller.go
@@ -104,7 +104,10 @@ func (c *ReportController) calculateMonthlyReport(_ pipeline.Context) error {
 	reporter := timesheet.NewReporter(c.Attendances, c.Leaves, c.Employee, c.Contracts).
 		SetMonth(c.Input.Year, c.Input.Month).
 		SetTimeZone("Europe/Zurich") // hardcoded for now
-	report := reporter.CalculateMonthlyReport()
+	report, err := reporter.CalculateMonthlyReport()
+	if err != nil {
+		return err
+	}
 	values := c.ReportView.GetValuesForMonthlyReport(report, c.Payslip)
 	return c.Echo.Render(http.StatusOK, monthlyReportTemplateName, values)
 }
@@ -113,7 +116,10 @@ func (c *ReportController) calculateYearlyReport(_ pipeline.Context) error {
 	reporter := timesheet.NewReporter(c.Attendances, c.Leaves, c.Employee, c.Contracts).
 		SetMonth(c.Input.Year, 1).
 		SetTimeZone("Europe/Zurich") // hardcoded for now
-	report := reporter.CalculateYearlyReport()
+	report, err := reporter.CalculateYearlyReport()
+	if err != nil {
+		return err
+	}
 	values := c.ReportView.GetValuesForYearlyReport(report)
 	return c.Echo.Render(http.StatusOK, yearlyReportTemplateName, values)
 }


### PR DESCRIPTION
## Summary

Previously it was only visible in the logs and the report showed empty values.
This is bad UX since it's not very transparent why it's empty.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
