### PR TITLE
Fix date range calculations of yearly report

### DIFF
--- a/pkg/web/overtimereport/overtimereport_controller.go
+++ b/pkg/web/overtimereport/overtimereport_controller.go
@@ -76,13 +76,15 @@ func (c *ReportController) fetchContracts(_ pipeline.Context) error {
 }
 
 func (c *ReportController) fetchAttendances(_ pipeline.Context) error {
-	attendances, err := c.OdooClient.FetchAttendancesBetweenDates(c.Employee.ID, c.Input.GetLastDayFromPreviousMonth(), c.Input.GetFirstDayOfNextMonth())
+	begin, end := c.Input.GetDateRange()
+	attendances, err := c.OdooClient.FetchAttendancesBetweenDates(c.Employee.ID, begin, end)
 	c.Attendances = attendances
 	return err
 }
 
 func (c *ReportController) fetchLeaves(_ pipeline.Context) error {
-	leaves, err := c.OdooClient.FetchLeavesBetweenDates(c.Employee.ID, c.Input.GetLastDayFromPreviousMonth(), c.Input.GetFirstDayOfNextMonth())
+	begin, end := c.Input.GetDateRange()
+	leaves, err := c.OdooClient.FetchLeavesBetweenDates(c.Employee.ID, begin, end)
 	c.Leaves = leaves
 	return err
 }

--- a/pkg/web/reportconfig/config_request.go
+++ b/pkg/web/reportconfig/config_request.go
@@ -65,3 +65,27 @@ func (i ReportRequest) GetLastDayFromPreviousMonth() time.Time {
 func (i ReportRequest) GetFirstDayOfNextMonth() time.Time {
 	return i.GetFirstDayOfMonth().AddDate(0, 1, 0)
 }
+
+// GetFirstDayOfYear returns the first day of the ReportRequest.Year in time.UTC at midnight.
+func (i ReportRequest) GetFirstDayOfYear() time.Time {
+	return time.Date(i.Year, time.January, 1, 0, 0, 0, 0, time.UTC)
+}
+
+// GetFirstDayOfNextYear returns the first day of the year after ReportRequest.Year in time.UTC at midnight.
+func (i ReportRequest) GetFirstDayOfNextYear() time.Time {
+	return time.Date(i.Year+1, time.January, 1, 0, 0, 0, 0, time.UTC)
+}
+
+// GetLastDayFromPreviousYear returns GetFirstDayOfYear subtracted by 1 day.
+func (i ReportRequest) GetLastDayFromPreviousYear() time.Time {
+	return i.GetFirstDayOfYear().AddDate(0, 0, -1)
+}
+
+// GetDateRange returns the appropriate `begin` and `end` dates, taking into account yearly reports.
+func (i ReportRequest) GetDateRange() (time.Time, time.Time) {
+	if i.Month == 0 {
+		return i.GetLastDayFromPreviousYear(), i.GetFirstDayOfNextYear()
+	}
+
+	return i.GetLastDayFromPreviousMonth(), i.GetFirstDayOfNextMonth()
+}


### PR DESCRIPTION
When calculating the date ranges to use for fetching data from Odoo,
take into account yearly reports. The current implementation only ever
fetches data in January.

Fixes: #70