### PR TITLE
Add Out-of-office hours column to employee report

### DIFF
--- a/pkg/timesheet/dailysummary_test.go
+++ b/pkg/timesheet/dailysummary_test.go
@@ -107,7 +107,7 @@ func TestDailySummary_CalculateOvertime(t *testing.T) {
 				Shifts:   tt.givenShifts,
 				FTERatio: 1,
 			}
-			result := s.CalculateOvertime()
+			result := s.CalculateOvertimeSummary().Overtime()
 			assert.Equal(t, tt.expectedOvertime, result)
 		})
 	}
@@ -168,7 +168,7 @@ func TestDailySummary_CalculateDailyMaxHours(t *testing.T) {
 				FTERatio: tt.givenFteRatio,
 				Absences: tt.givenAbsences,
 			}
-			result := s.CalculateDailyMax()
+			result := s.calculateDailyMax()
 			assert.Equal(t, time.Duration(tt.expectedHours*float64(time.Hour)), result)
 		})
 	}

--- a/pkg/timesheet/report.go
+++ b/pkg/timesheet/report.go
@@ -129,9 +129,10 @@ func (r *ReportBuilder) CalculateReport() (Report, error) {
 
 	summary := Summary{}
 	for _, dailySummary := range dailySummaries {
-		summary.TotalOvertime += dailySummary.CalculateOvertime()
-		summary.TotalExcusedTime += dailySummary.CalculateExcusedTime()
-		summary.TotalWorkedTime += dailySummary.CalculateWorkingTime()
+		overtimeSummary := dailySummary.CalculateOvertimeSummary()
+		summary.TotalOvertime += overtimeSummary.Overtime()
+		summary.TotalExcusedTime += overtimeSummary.ExcusedTime()
+		summary.TotalWorkedTime += overtimeSummary.WorkingTime()
 		if dailySummary.IsHoliday() {
 			summary.TotalLeave += 1
 		}

--- a/pkg/timesheet/report.go
+++ b/pkg/timesheet/report.go
@@ -46,9 +46,10 @@ type AbsenceBlock struct {
 }
 
 type Summary struct {
-	TotalOvertime    time.Duration
-	TotalExcusedTime time.Duration
-	TotalWorkedTime  time.Duration
+	TotalOvertime        time.Duration
+	TotalExcusedTime     time.Duration
+	TotalWorkedTime      time.Duration
+	TotalOutOfOfficeTime time.Duration
 	// TotalLeave is the amount of paid leave days.
 	// This value respects FTE ratio, e.g. in a 50% ratio a public holiday is still counted as '1d'.
 	TotalLeave      float64
@@ -133,6 +134,7 @@ func (r *ReportBuilder) CalculateReport() (Report, error) {
 		summary.TotalOvertime += overtimeSummary.Overtime()
 		summary.TotalExcusedTime += overtimeSummary.ExcusedTime()
 		summary.TotalWorkedTime += overtimeSummary.WorkingTime()
+		summary.TotalOutOfOfficeTime += overtimeSummary.OutOfOfficeTime
 		if dailySummary.IsHoliday() {
 			summary.TotalLeave += 1
 		}

--- a/pkg/web/controller/view.go
+++ b/pkg/web/controller/view.go
@@ -56,13 +56,14 @@ func (v BaseView) GetPreviousMonth(year, month int) (int, int) {
 
 // FormatDailySummary returns Values with sensible format.
 func (v BaseView) FormatDailySummary(daily *timesheet.DailySummary) Values {
+	overtimeSummary := daily.CalculateOvertimeSummary()
 	basic := Values{
 		"Weekday":       daily.Date.Weekday(),
 		"Date":          daily.Date.Format(odoo.DateFormat),
 		"Workload":      daily.FTERatio * 100,
-		"ExcusedHours":  v.FormatDurationInHours(daily.CalculateExcusedTime()),
-		"WorkedHours":   v.FormatDurationInHours(daily.CalculateWorkingTime()),
-		"OvertimeHours": v.FormatDurationInHours(daily.CalculateOvertime()),
+		"ExcusedHours":  v.FormatDurationInHours(overtimeSummary.ExcusedTime()),
+		"WorkedHours":   v.FormatDurationInHours(overtimeSummary.WorkingTime()),
+		"OvertimeHours": v.FormatDurationInHours(overtimeSummary.Overtime()),
 		"LeaveType":     "",
 	}
 	if daily.HasAbsences() {

--- a/pkg/web/employeereport/employeereport_view.go
+++ b/pkg/web/employeereport/employeereport_view.go
@@ -57,6 +57,7 @@ func (v *reportView) getValuesForReport(report timesheet.Report, previousPayslip
 		"Leaves":                          report.Summary.TotalLeave,
 		"ExcusedHours":                    v.FormatDurationInHours(report.Summary.TotalExcusedTime),
 		"WorkedHours":                     v.FormatDurationInHours(report.Summary.TotalWorkedTime),
+		"OutOfOfficeHours":                v.FormatDurationInHours(report.Summary.TotalOutOfOfficeTime),
 		"OvertimeHours":                   v.FormatDurationInHours(report.Summary.TotalOvertime),
 		"PreviousBalance":                 previousBalanceCellText,
 		"NextBalance":                     nextBalanceCellText,

--- a/pkg/web/overtimereport/monthlyreport_view.go
+++ b/pkg/web/overtimereport/monthlyreport_view.go
@@ -39,7 +39,7 @@ func (v *reportView) formatMonthlySummary(s timesheet.Summary, payslip *model.Pa
 func (v *reportView) GetValuesForMonthlyReport(report timesheet.Report, payslip *model.Payslip) controller.Values {
 	formatted := make([]controller.Values, 0)
 	for _, summary := range report.DailySummaries {
-		if summary.IsWeekend() && summary.CalculateWorkingTime() == 0 {
+		if summary.IsWeekend() && summary.CalculateOvertimeSummary().WorkingTime() == 0 {
 			continue
 		}
 		formatted = append(formatted, v.FormatDailySummary(summary))

--- a/pkg/web/reportconfig/config_view.go
+++ b/pkg/web/reportconfig/config_view.go
@@ -17,7 +17,7 @@ type ConfigView struct {
 func (v *ConfigView) GetConfigurationValues(report timesheet.Report) controller.Values {
 	formatted := make([]controller.Values, 0)
 	for _, summary := range report.DailySummaries {
-		if summary.IsWeekend() && summary.CalculateWorkingTime() == 0 {
+		if summary.IsWeekend() && summary.CalculateOvertimeSummary().WorkingTime() == 0 {
 			continue
 		}
 		formatted = append(formatted, v.FormatDailySummary(summary))

--- a/templates/employeereport.html
+++ b/templates/employeereport.html
@@ -75,6 +75,7 @@
         <th scope="col">Leaves</th>
         <th scope="col">Excused hours</th>
         <th scope="col">Worked hours</th>
+        <th scope="col">(Out of office hours, real)</th>
         <th scope="col">{{ .LastMonth }} Payslip</th>
         <th scope="col">Overtime delta</th>
         <th scope="col">Proposed balance</th>
@@ -89,6 +90,7 @@
         <td>{{ .Leaves }}d</td>
         <td>{{ .ExcusedHours }}</td>
         <td>{{ .WorkedHours }}</td>
+        <td>{{ .OutOfOfficeHours }}</td>
         <td>{{ .PreviousBalance }}</td>
         <td>{{ .OvertimeHours }}</td>
         <td>{{ .ProposedBalance }}</td>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -10,7 +10,13 @@
     <link href="/static/bootstrap.min.css" rel="stylesheet">
     <script src="/static/bootstrap.min.js" rel="script"></script>
 </head>
-
+<style>
+    @media (min-width: 2000px) {
+    .container{
+        max-width: 2000px;
+    }
+}
+</style>
 <body>
 <main class="container">
     {{ template "nav" . }}


### PR DESCRIPTION
## Summary

* Internal refactoring how overtime is calculated. The changes allow to access individual sums of certain types of hours per work day.
* Thanks to the refactoring, a new column `ouf of office, real` is displayed in the employee report, next to `worked hours`. This column shows specifically the share of out-of-office hours (without 1.5 multiplication) that ultimately make up `worked hours`.
* Since the employee report is only accessible for HR managers, this column is exclusive to HR managers in Odoo.
* Closes #91 
* As a side change, the max width of the employee report has been increased on large screens (> 2000px) to better fit the larger table.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update the documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
