### PR TITLE
Fix nil pointer panic in error handling for employee report

### DIFF
--- a/pkg/web/employeereport/employeereport_controller.go
+++ b/pkg/web/employeereport/employeereport_controller.go
@@ -2,9 +2,9 @@ package employeereport
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	pipeline "github.com/ccremer/go-command-pipeline"
@@ -188,7 +188,8 @@ func (c *EmployeeReport) fetchNextPayslip(ctx context.Context) error {
 }
 
 func (c *EmployeeReport) ignoreNoContractFound(_ context.Context, err error) error {
-	if strings.Contains(err.Error(), "no contract found that covers date") {
+	var noContractErr *model.NoContractCoversDateErr
+	if errors.As(err, &noContractErr) {
 		return nil
 	}
 	return err

--- a/pkg/web/employeereport/employeereport_controller_test.go
+++ b/pkg/web/employeereport/employeereport_controller_test.go
@@ -1,0 +1,39 @@
+package employeereport
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vshn/odootools/pkg/odoo/model"
+)
+
+func Test_EmployeeReport_ignoreNoContractFound(t *testing.T) {
+	tests := map[string]struct {
+		givenError    error
+		expectedError string
+	}{
+		"GivenNilError_ThenExpectNil": {
+			givenError: nil, expectedError: "",
+		},
+		"GivenAnyError_ThenExpectSameError": {
+			givenError:    errors.New("test"),
+			expectedError: "test",
+		},
+		"GivenNoContractCoversDateError_ThenExpectNil": {
+			givenError:    &model.NoContractCoversDateErr{Err: errors.New("no contract")},
+			expectedError: "",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			r := &EmployeeReport{}
+			err := r.ignoreNoContractFound(nil, tc.givenError)
+			if tc.expectedError != "" {
+				assert.EqualError(t, err, tc.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

* Adds a custom error implementation for "contract found"
* Fixes the following panic:
```
..."method":"POST","uri":"/report"

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x84903e]

goroutine 199 [running]:
github.com/vshn/odootools/pkg/web/employeereport.(*EmployeeReport).ignoreNoContractFound(0xc0003e7cc0?, {0x84cc19?, 0xc00029a480?}, {0x0, 0x0})
	/home/runner/work/odootools/odootools/pkg/web/employeereport/employeereport_controller.go:191 +0x1e
```

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update the documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
