### PR TITLE
Rework monthly report summary

### DIFF
--- a/pkg/web/overtimereport/monthlyreport_view.go
+++ b/pkg/web/overtimereport/monthlyreport_view.go
@@ -68,6 +68,7 @@ func (v *reportView) GetValuesForMonthlyReport(report timesheet.Report, previous
 			"NextMonthLink":     fmt.Sprintf(linkFormat, report.Employee.ID, nextYear, nextMonth),
 			"PreviousMonthLink": fmt.Sprintf(linkFormat, report.Employee.ID, prevYear, prevMonth),
 		},
-		"Username": report.Employee.Name,
+		"Username":         report.Employee.Name,
+		"MonthDisplayName": fmt.Sprintf("%s %d", report.From.Month(), report.From.Year()),
 	}
 }

--- a/templates/help.html
+++ b/templates/help.html
@@ -50,7 +50,7 @@
 <div>
     <h3>Overtime delta</h3>
     <p>
-        The overtime delta in the monthly or yearly reports is only indicating a difference towards the theoretical target work time after deducting all applicable absences.
+        The "Total Overtime" in the monthly or yearly reports is only indicating a difference towards the theoretical target work time after deducting all applicable absences.
         It is <strong>not</strong> indicating your current balance, but rather just showing whether you've worked more or less towards the contracted working schedule.
     </p>
 </div>
@@ -69,8 +69,9 @@
     <p>
         For this reason, the overtime balance is stored in your payslip associated with the corresponding month.
         This is done by PeopleOps.
-        That means the displayed overtime balance in the reports is merely a <strong>non-guaranteed prediction</strong> that is calculated from the last month's payslip with the overtime delta.
-        The value in the <i>payslip</i> is ultimately <i>authoritative</i> of your overtime balance.
+        That means the displayed overtime balance in "Calculated balance" in the reports is merely a <strong>non-guaranteed calculation</strong> that is calculated from the last month's payslip with the overtime delta.
+        The value in the <i>payslip</i> is ultimately <i>authoritative</i> of your overtime balance and displayed in <mark>"Definitive Balance"</mark> field.
+        This field is only available after PeopleOps has created the payslip for the according month.
     </p>
 </div>
 

--- a/templates/overtimereport-monthly.html
+++ b/templates/overtimereport-monthly.html
@@ -1,5 +1,6 @@
 {{ define "main" }}
-<h1>Attendance for {{ .Username }}</h1>
+<h1>Attendance for {{ .Username }}<small class="text-muted"> {{ .MonthDisplayName }}</small></h1>
+<div class="float"></div>
 {{ with .Error }}
 <div class="alert alert-danger" role="alert">{{ . }}</div>
 {{ end }}

--- a/templates/overtimereport-monthly.html
+++ b/templates/overtimereport-monthly.html
@@ -39,18 +39,36 @@
         <th scope="col"></th>
         <th scope="col"></th>
         <th scope="col">Total Leaves</th>
-        <th scope="col"></th>
+        <th scope="col">Total Excused</th>
+        <th scope="col">Total Worked</th>
         <th scope="col">Total Overtime</th>
-        <th scope="col">New Balance</th>
     </tr>
     <tr>
         <td></td>
         <td></td>
         <td></td>
         <td>{{ .Summary.TotalLeaves }}</td>
-        <td></td>
+        <td>{{ .Summary.TotalExcused }}</td>
+        <td>{{ .Summary.TotalWorked }}</td>
         <td>{{ .Summary.TotalOvertime }}</td>
+    </tr>
+    <tr>
+        <th scope="col"></th>
+        <th scope="col"></th>
+        <th scope="col"></th>
+        <th scope="col"></th>
+        <th scope="col"></th>
+        <th scope="col">Calculated Balance</th>
+        <th scope="col">Definitive Balance</th>
+    </tr>
+    <tr>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
         <td>{{ .Summary.NewOvertimeBalance }}</td>
+        <td>{{ .Summary.CurrentPayslipBalance }}</td>
     </tr>
     </tfoot>
 </table>


### PR DESCRIPTION
## Summary

* This PR introduces more details like total excused and worked hours.
* "new balance" is renamed into "calculated balance".
* New field "definitive balance" now shows the balance that is in the current month's payslip, if any.
* Title now also shows which month and year you're looking at

This is because sometimes there are discrepancies  between calculated and actual overtime made with manual correction from peopleops.

Fixes #128 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update the documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
