### PR TITLE
Include current time in monthly report as sign_in

### DIFF
--- a/pkg/odoo/model/actionreason.go
+++ b/pkg/odoo/model/actionreason.go
@@ -18,6 +18,11 @@ type ActionReason struct {
 	Name string
 }
 
+const (
+	ActionSignOut = "sign_out"
+	ActionSignIn  = "sign_in"
+)
+
 // String implements fmt.Stringer.
 func (reason *ActionReason) String() string {
 	if reason == nil {

--- a/pkg/odoo/model/attendance.go
+++ b/pkg/odoo/model/attendance.go
@@ -70,3 +70,24 @@ func (l AttendanceList) FilterAttendanceBetweenDates(from, to time.Time) Attenda
 	}
 	return filteredAttendances
 }
+
+// AddCurrentTimeAsSignOut adds an Attendance with timesheet.ActionSignOut reason and with the current time.
+// An attendance is only added if the last Attendance in the list is timesheet.ActionSignIn.
+func (l AttendanceList) AddCurrentTimeAsSignOut() AttendanceList {
+	if len(l.Items) == 0 {
+		return l
+	}
+	lastAttendance := l.Items[len(l.Items)-1]
+	if lastAttendance.Action != ActionSignIn {
+		return l
+	}
+
+	now := odoo.Date(time.Now())
+	// fake a sign_out
+	l.Items = append(l.Items, Attendance{
+		DateTime: &now,
+		Action:   ActionSignOut,
+		Reason:   lastAttendance.Reason,
+	})
+	return l
+}

--- a/pkg/timesheet/report.go
+++ b/pkg/timesheet/report.go
@@ -27,11 +27,6 @@ const (
 // for testing purposes
 var now = time.Now
 
-const (
-	ActionSignIn  = "sign_in"
-	ActionSignOut = "sign_out"
-)
-
 type AttendanceShift struct {
 	// Start is the localized beginning time of the attendance
 	Start time.Time
@@ -154,13 +149,13 @@ func (r *ReportBuilder) reduceAttendancesToShifts(attendances model.AttendanceLi
 	shifts := make([]AttendanceShift, 0)
 	var tmpShift AttendanceShift
 	for _, attendance := range attendances.Items {
-		if attendance.Action == ActionSignIn {
+		if attendance.Action == model.ActionSignIn {
 			tmpShift = AttendanceShift{
 				Start:  attendance.DateTime.ToTime().In(r.timezone),
 				Reason: attendance.Reason.String(),
 			}
 		}
-		if attendance.Action == ActionSignOut {
+		if attendance.Action == model.ActionSignOut {
 			tmpShift.End = attendance.DateTime.ToTime().In(r.timezone)
 			shifts = append(shifts, tmpShift)
 		}

--- a/pkg/timesheet/report_test.go
+++ b/pkg/timesheet/report_test.go
@@ -107,8 +107,8 @@ func TestReporter_ReduceAttendancesToShifts(t *testing.T) {
 	}{
 		"GivenAttendancesInUTC_WhenReducing_ThenApplyLocalZone": {
 			givenAttendances: []model.Attendance{
-				{DateTime: newDateTime(t, "2021-02-03 19:00"), Action: ActionSignIn}, // these times are UTC
-				{DateTime: newDateTime(t, "2021-02-03 22:59"), Action: ActionSignOut},
+				{DateTime: newDateTime(t, "2021-02-03 19:00"), Action: model.ActionSignIn}, // these times are UTC
+				{DateTime: newDateTime(t, "2021-02-03 22:59"), Action: model.ActionSignOut},
 			},
 			expectedShifts: []AttendanceShift{
 				{Start: newDateTime(t, "2021-02-03 19:00").ToTime().In(localzone(t)),
@@ -118,10 +118,10 @@ func TestReporter_ReduceAttendancesToShifts(t *testing.T) {
 		},
 		"GivenAttendancesInUTC_WhenSplitOverMidnight_ThenSplitInTwoDays": {
 			givenAttendances: []model.Attendance{
-				{DateTime: newDateTime(t, "2021-02-03 19:00"), Action: ActionSignIn}, // these times are UTC
-				{DateTime: newDateTime(t, "2021-02-03 22:59"), Action: ActionSignOut},
-				{DateTime: newDateTime(t, "2021-02-03 23:00"), Action: ActionSignIn},
-				{DateTime: newDateTime(t, "2021-02-04 00:00"), Action: ActionSignOut},
+				{DateTime: newDateTime(t, "2021-02-03 19:00"), Action: model.ActionSignIn}, // these times are UTC
+				{DateTime: newDateTime(t, "2021-02-03 22:59"), Action: model.ActionSignOut},
+				{DateTime: newDateTime(t, "2021-02-03 23:00"), Action: model.ActionSignIn},
+				{DateTime: newDateTime(t, "2021-02-04 00:00"), Action: model.ActionSignOut},
 			},
 			expectedShifts: []AttendanceShift{
 				{

--- a/pkg/web/overtimereport/overtimereport_controller.go
+++ b/pkg/web/overtimereport/overtimereport_controller.go
@@ -81,7 +81,7 @@ func (c *ReportController) fetchContracts(ctx context.Context) error {
 func (c *ReportController) fetchAttendances(ctx context.Context) error {
 	begin, end := c.Input.GetDateRange()
 	attendances, err := c.OdooClient.FetchAttendancesBetweenDates(ctx, c.Employee.ID, begin, end)
-	c.Attendances = attendances
+	c.Attendances = attendances.AddCurrentTimeAsSignOut()
 	return err
 }
 

--- a/pkg/web/reportconfig/config_controller.go
+++ b/pkg/web/reportconfig/config_controller.go
@@ -112,21 +112,9 @@ func (c *ConfigController) fetchAttendanceOfCurrentWeek(ctx context.Context) err
 		return err
 	}
 	attendances.SortByDate()
-	attendances = attendances.FilterAttendanceBetweenDates(c.StartOfWeek, c.EndOfWeek)
-	c.Attendances = attendances
-	if len(attendances.Items) > 0 {
-		lastAttendance := attendances.Items[len(attendances.Items)-1]
-		if lastAttendance.Action == timesheet.ActionSignIn {
-			c.view.isSignedIn = true
-			now := odoo.Date(time.Now())
-			// fake a sign_out
-			c.Attendances.Items = append(c.Attendances.Items, model.Attendance{
-				DateTime: &now,
-				Action:   timesheet.ActionSignOut,
-				Reason:   lastAttendance.Reason,
-			})
-		}
-	}
+	c.Attendances = attendances.
+		FilterAttendanceBetweenDates(c.StartOfWeek, c.EndOfWeek).
+		AddCurrentTimeAsSignOut()
 	return nil
 }
 


### PR DESCRIPTION

## Summary

This change includes the current time and adds a "fake sign_out" so that the overtime calculation of  "today" is respecting a currently-signed-in shift.
The result is that a "current month" report now also includes the worked hours since last sign in and doesn't show an incorrect overtime. For example, for an 8h day, if a user worked for 7h already, the monthly report shows only a 1h instead of 8h undertime for "today".

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update the documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
