### PR TITLE
Introduce support for different time zones in monthly report

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,3 +121,14 @@ In the end it doesn't matter:
 
 The workload ratio can be retrieved from Odoo via the "Contracts" model.
 However, special read access needs to be granted so that they can be queried for their own user.
+
+### Timezone Support
+
+A custom field in the payslip model is required (`x_timezone`) to save the timezone of a user for a certain month.
+We considered using the timezone from the browser or make it toggleable in the UI, but that doesn't cover enough cases.
+
+PeopleOps have the ability to create reports over all employees.
+For that reason there can't be a single timezone info (e.g. from Browser) because that would apply to every employee.
+Also, throughout a year an employee can switch zones, so the yearly report has to know which months are different.
+
+So we need a historic view per user per month and that's where the custom field in the payslip comes in.

--- a/flags.go
+++ b/flags.go
@@ -1,6 +1,8 @@
 package main
 
-import "github.com/urfave/cli/v2"
+import (
+	"github.com/urfave/cli/v2"
+)
 
 func newOdooURLFlag() *cli.StringFlag {
 	return &cli.StringFlag{
@@ -59,5 +61,14 @@ func newTLSKeyFlag() *cli.StringFlag {
 		Name:    "tls-key",
 		Usage:   "The path to a certificate private key file to serve",
 		EnvVars: []string{"TLS_KEY"},
+	}
+}
+
+func newDefaultTimezoneFlag() *cli.StringFlag {
+	return &cli.StringFlag{
+		Name:    "default-timezone",
+		Usage:   "Default timezone to use in report calculations if unspecified in employee's records",
+		EnvVars: []string{"DEFAULT_TZ"},
+		Value:   "Europe/Zurich",
 	}
 }

--- a/pkg/odoo/model/attendance.go
+++ b/pkg/odoo/model/attendance.go
@@ -73,7 +73,7 @@ func (l AttendanceList) FilterAttendanceBetweenDates(from, to time.Time) Attenda
 
 // AddCurrentTimeAsSignOut adds an Attendance with timesheet.ActionSignOut reason and with the current time.
 // An attendance is only added if the last Attendance in the list is timesheet.ActionSignIn.
-func (l AttendanceList) AddCurrentTimeAsSignOut() AttendanceList {
+func (l AttendanceList) AddCurrentTimeAsSignOut(tz *time.Location) AttendanceList {
 	if len(l.Items) == 0 {
 		return l
 	}
@@ -82,7 +82,7 @@ func (l AttendanceList) AddCurrentTimeAsSignOut() AttendanceList {
 		return l
 	}
 
-	now := odoo.Date(time.Now())
+	now := odoo.Date(time.Now().In(tz))
 	// fake a sign_out
 	l.Items = append(l.Items, Attendance{
 		DateTime: &now,

--- a/pkg/odoo/model/payslip_test.go
+++ b/pkg/odoo/model/payslip_test.go
@@ -36,7 +36,7 @@ func TestPayslip_ParseOvertime(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			p := Payslip{Overtime: tt.givenOvertime}
+			p := Payslip{XOvertime: tt.givenOvertime}
 			result, err := p.ParseOvertime()
 			if tt.expectedError != "" {
 				assert.EqualError(t, err, tt.expectedError)

--- a/pkg/odoo/model/user.go
+++ b/pkg/odoo/model/user.go
@@ -1,0 +1,39 @@
+package model
+
+import (
+	"context"
+
+	"github.com/vshn/odootools/pkg/odoo"
+)
+
+type User struct {
+	ID       int            `json:"id"`
+	Name     string         `json:"name"`
+	TimeZone *odoo.TimeZone `json:"tz,omitempty"`
+	Email    string         `json:"email"`
+}
+
+func (o Odoo) FetchUserByID(ctx context.Context, id int) (*User, error) {
+	users, err := o.readUser(ctx, []odoo.Filter{
+		[]interface{}{"id", "=", id},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if users.Len() > 0 {
+		return &users.Items[0], nil
+	}
+	return nil, nil
+}
+
+func (o Odoo) readUser(ctx context.Context, domainFilters []odoo.Filter) (odoo.List[User], error) {
+	result := odoo.List[User]{}
+	err := o.querier.SearchGenericModel(ctx, odoo.SearchReadModel{
+		Model:  "res.users",
+		Domain: domainFilters,
+		Fields: []string{"name", "tz", "email"},
+		Limit:  0,
+		Offset: 0,
+	}, &result)
+	return result, err
+}

--- a/pkg/odoo/timezone.go
+++ b/pkg/odoo/timezone.go
@@ -33,3 +33,19 @@ func (tz *TimeZone) Location() *time.Location {
 	}
 	return tz.loc
 }
+
+// LocationOrDefault returns the location if it's defined, or given default it not.
+func (tz *TimeZone) LocationOrDefault(def *time.Location) *time.Location {
+	if tz.IsEmpty() {
+		return def
+	}
+	return tz.Location()
+}
+
+// IsEmpty returns true if the location is nil.
+func (tz *TimeZone) IsEmpty() bool {
+	if tz == nil || tz.Location() == nil {
+		return true
+	}
+	return false
+}

--- a/pkg/odoo/timezone.go
+++ b/pkg/odoo/timezone.go
@@ -1,0 +1,28 @@
+package odoo
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+)
+
+type TimeZone time.Location
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (tz *TimeZone) UnmarshalJSON(b []byte) error {
+	ts := bytes.Trim(b, `"`)
+	loc, err := time.LoadLocation(string(ts))
+	if err != nil {
+		return fmt.Errorf("cannot unmarshal json: %w", err)
+	}
+	*tz = TimeZone(*loc)
+	return nil
+}
+
+func (tz *TimeZone) Location() *time.Location {
+	if tz == nil {
+		return nil
+	}
+	l := time.Location(*tz)
+	return &l
+}

--- a/pkg/odoo/timezone.go
+++ b/pkg/odoo/timezone.go
@@ -2,20 +2,28 @@ package odoo
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"time"
 )
 
-type TimeZone time.Location
+// TimeZone represents a time zone in Odoo.
+type TimeZone struct {
+	loc *time.Location
+}
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (tz *TimeZone) UnmarshalJSON(b []byte) error {
+	var f bool
+	if err := json.Unmarshal(b, &f); err == nil || string(b) == "false" || string(b) == "" {
+		return nil
+	}
 	ts := bytes.Trim(b, `"`)
 	loc, err := time.LoadLocation(string(ts))
 	if err != nil {
 		return fmt.Errorf("cannot unmarshal json: %w", err)
 	}
-	*tz = TimeZone(*loc)
+	tz.loc = loc
 	return nil
 }
 
@@ -23,6 +31,5 @@ func (tz *TimeZone) Location() *time.Location {
 	if tz == nil {
 		return nil
 	}
-	l := time.Location(*tz)
-	return &l
+	return tz.loc
 }

--- a/pkg/odoo/timezone_test.go
+++ b/pkg/odoo/timezone_test.go
@@ -13,11 +13,13 @@ func TestTimeZone_UnmarshalJSON(t *testing.T) {
 		givenInput       string
 		expectedLocation *time.Location
 	}{
-		"UTC":           {givenInput: "UTC", expectedLocation: time.UTC},
-		"Local":         {givenInput: "Local", expectedLocation: time.Local},
-		"EuropeZurich":  {givenInput: `"Europe/Zurich"`, expectedLocation: mustLoadLocation("Europe/Zurich")},
-		"CanadaPacific": {givenInput: "Canada/Pacific", expectedLocation: mustLoadLocation("Canada/Pacific")},
-		"PST8PDT":       {givenInput: "PST8PDT", expectedLocation: mustLoadLocation("PST8PDT")},
+		"false":            {givenInput: "false", expectedLocation: nil},
+		"empty":            {givenInput: "", expectedLocation: nil},
+		"UTC":              {givenInput: "UTC", expectedLocation: time.UTC},
+		"Local":            {givenInput: "Local", expectedLocation: time.Local},
+		"EuropeZurich":     {givenInput: `"Europe/Zurich"`, expectedLocation: mustLoadLocation("Europe/Zurich")},
+		"AmericaVancouver": {givenInput: "America/Vancouver", expectedLocation: mustLoadLocation("America/Vancouver")},
+		"PST8PDT":          {givenInput: "PST8PDT", expectedLocation: mustLoadLocation("PST8PDT")},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/odoo/timezone_test.go
+++ b/pkg/odoo/timezone_test.go
@@ -1,0 +1,42 @@
+package odoo
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeZone_UnmarshalJSON(t *testing.T) {
+	tests := map[string]struct {
+		givenInput       string
+		expectedLocation *time.Location
+	}{
+		"UTC":           {givenInput: "UTC", expectedLocation: time.UTC},
+		"Local":         {givenInput: "Local", expectedLocation: time.Local},
+		"EuropeZurich":  {givenInput: `"Europe/Zurich"`, expectedLocation: mustLoadLocation("Europe/Zurich")},
+		"CanadaPacific": {givenInput: "Canada/Pacific", expectedLocation: mustLoadLocation("Canada/Pacific")},
+		"PST8PDT":       {givenInput: "PST8PDT", expectedLocation: mustLoadLocation("PST8PDT")},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			subject := &TimeZone{}
+			err := subject.UnmarshalJSON([]byte(tt.givenInput))
+			require.NoError(t, err)
+			if tt.expectedLocation == nil {
+				assert.Nil(t, subject.Location())
+				return
+			}
+			assert.Equal(t, tt.expectedLocation, subject.Location())
+		})
+	}
+}
+
+func mustLoadLocation(name string) *time.Location {
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		panic(err)
+	}
+	return loc
+}

--- a/pkg/timesheet/report.go
+++ b/pkg/timesheet/report.go
@@ -91,11 +91,8 @@ func (r *ReportBuilder) SetRange(from, to time.Time) *ReportBuilder {
 	return r
 }
 
-func (r *ReportBuilder) SetTimeZone(zone string) *ReportBuilder {
-	loc, err := time.LoadLocation(zone)
-	if err == nil {
-		r.timezone = loc
-	}
+func (r *ReportBuilder) SetTimeZone(location *time.Location) *ReportBuilder {
+	r.timezone = location
 	return r
 }
 

--- a/pkg/timesheet/report.go
+++ b/pkg/timesheet/report.go
@@ -112,8 +112,8 @@ func (r *ReportBuilder) CalculateReport() (Report, error) {
 	if err != nil {
 		return Report{
 			Employee: r.employee,
-			From:     r.from,
-			To:       r.to,
+			From:     r.from.In(r.timezone),
+			To:       r.to.In(r.timezone),
 		}, err
 	}
 
@@ -136,8 +136,8 @@ func (r *ReportBuilder) CalculateReport() (Report, error) {
 		DailySummaries: dailySummaries,
 		Summary:        summary,
 		Employee:       r.employee,
-		From:           r.from,
-		To:             r.to,
+		From:           r.from.In(r.timezone),
+		To:             r.to.In(r.timezone),
 	}, nil
 }
 

--- a/pkg/timesheet/report.go
+++ b/pkg/timesheet/report.go
@@ -1,6 +1,7 @@
 package timesheet
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/vshn/odootools/pkg/odoo"
@@ -33,6 +34,22 @@ type AttendanceShift struct {
 	// End is the localized finish time of the attendance
 	End    time.Time
 	Reason string
+}
+
+// String implements fmt.Stringer.
+func (s *AttendanceShift) String() string {
+	if s == nil {
+		return ""
+	}
+	return fmt.Sprintf("AttendanceShift[Start: %s, End: %s, Duration, %s, Reason: %s]", s.Start, s.End, s.Duration(), s.Reason)
+}
+
+// Duration returns the difference between AttendanceShift.Start and AttendanceShift.End.
+func (s *AttendanceShift) Duration() time.Duration {
+	if s == nil {
+		return 0
+	}
+	return s.End.Sub(s.Start)
 }
 
 type AbsenceBlock struct {
@@ -104,7 +121,7 @@ func (r *ReportBuilder) SkipClampingToNow(skip bool) *ReportBuilder {
 }
 
 func (r *ReportBuilder) CalculateReport() (Report, error) {
-	filteredAttendances := r.attendances.FilterAttendanceBetweenDates(r.from.In(r.timezone), r.to)
+	filteredAttendances := r.attendances.FilterAttendanceBetweenDates(r.from.In(r.timezone), r.to.In(r.timezone))
 	shifts := r.reduceAttendancesToShifts(filteredAttendances)
 	filteredLeaves := r.filterLeavesInTimeRange()
 	absences := r.reduceLeavesToBlocks(filteredLeaves)

--- a/pkg/web/controller/controller.go
+++ b/pkg/web/controller/controller.go
@@ -21,14 +21,6 @@ const HRManagerRoleKey = "HRManager"
 
 var DefaultTimeZone *time.Location
 
-func init() {
-	loc, err := time.LoadLocation("Europe/Zurich")
-	if err != nil {
-		panic(err)
-	}
-	DefaultTimeZone = loc
-}
-
 // SessionData is an additional data struct.
 // Its purpose is to store data in a session cookie in order to avoid repetitive Odoo API calls.
 type SessionData struct {

--- a/pkg/web/controller/controller.go
+++ b/pkg/web/controller/controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/vshn/odootools/pkg/odoo"
@@ -18,9 +19,26 @@ type BaseController struct {
 
 const HRManagerRoleKey = "HRManager"
 
+var DefaultTimeZone *time.Location
+
+func init() {
+	loc, err := time.LoadLocation("Europe/Zurich")
+	if err != nil {
+		panic(err)
+	}
+	DefaultTimeZone = loc
+}
+
 // SessionData is an additional data struct.
 // Its purpose is to store data in a session cookie in order to avoid repetitive Odoo API calls.
 type SessionData struct {
 	Employee *model.Employee `json:"employee"`
 	Roles    []string        `json:"roles"`
+}
+
+func TimezoneOrDefault(loc *odoo.TimeZone, def *time.Location) *time.Location {
+	if loc == nil || loc.Location() == nil {
+		return def
+	}
+	return loc.Location()
 }

--- a/pkg/web/employeereport/employeereport_controller.go
+++ b/pkg/web/employeereport/employeereport_controller.go
@@ -166,7 +166,7 @@ func (c *EmployeeReport) fetchLeaves(ctx context.Context) error {
 func (c *EmployeeReport) calculateMonthlyReport(_ context.Context) error {
 	reporter := timesheet.NewReporter(c.Attendances, c.Leaves, &c.Employee, c.Contracts).
 		SetRange(c.Start, c.Stop.AddDate(0, 0, 1)).
-		SetTimeZone("Europe/Zurich") // hardcoded for now
+		SetTimeZone(controller.TimezoneOrDefault(c.NextPayslip.TimeZone, controller.DefaultTimeZone))
 	report, err := reporter.CalculateReport()
 	c.Result = report
 	return err

--- a/pkg/web/employeereport/employeereport_view.go
+++ b/pkg/web/employeereport/employeereport_view.go
@@ -71,7 +71,7 @@ func (v *reportView) getOvertimeBalanceEditPreview(nextPayslip *model.Payslip, p
 	overtimeBalanceEditPreview = v.FormatDurationInHours(proposedBalance)
 	if nextPayslip != nil {
 		// next payslip exists
-		if existingValue := nextPayslip.GetOvertime(); existingValue != "" {
+		if existingValue := nextPayslip.Overtime(); existingValue != "" {
 			// payslip may have been updated already
 			return existingValue
 		}
@@ -80,7 +80,7 @@ func (v *reportView) getOvertimeBalanceEditPreview(nextPayslip *model.Payslip, p
 }
 
 func (v *reportView) getButtonText(nextPayslip *model.Payslip) string {
-	if nextPayslip == nil || nextPayslip.GetOvertime() == "" {
+	if nextPayslip == nil || nextPayslip.Overtime() == "" {
 		return "Save (New)"
 	}
 	return "Save (Update)"
@@ -103,7 +103,7 @@ func (v *reportView) getPreviousBalance(previousPayslip *model.Payslip) (cellTex
 		cellText = "<no payslip found>"
 		return
 	}
-	if previousPayslip.GetOvertime() == "" {
+	if previousPayslip.Overtime() == "" {
 		cellText = "<no overtime saved>"
 		return
 	}
@@ -113,7 +113,7 @@ func (v *reportView) getPreviousBalance(previousPayslip *model.Payslip) (cellTex
 		previousOvertime = 0
 		return
 	}
-	cellText = previousPayslip.GetOvertime()
+	cellText = previousPayslip.Overtime()
 	return
 }
 
@@ -127,7 +127,7 @@ func (v *reportView) getNextBalance(proposedBalance time.Duration, nextPayslip *
 	if nextPayslip == nil {
 		return "<no payslip found>", proposedBalance
 	}
-	if existing := nextPayslip.GetOvertime(); existing != "" {
+	if existing := nextPayslip.Overtime(); existing != "" {
 		cellText = existing
 		parsed, err := nextPayslip.ParseOvertime()
 		if err != nil {

--- a/pkg/web/employeereport/employeereport_view_test.go
+++ b/pkg/web/employeereport/employeereport_view_test.go
@@ -23,7 +23,7 @@ func TestReportView_getButtonText(t *testing.T) {
 			expectedButtonText: "Save (New)",
 		},
 		"GivenPayslip_WhenOvertimeSaved_ThenExpectSaveUpdate": {
-			givenNextPayslip:   &model.Payslip{Overtime: "2:00:00"},
+			givenNextPayslip:   &model.Payslip{XOvertime: "2:00:00"},
 			expectedButtonText: "Save (Update)",
 		},
 	}
@@ -53,12 +53,12 @@ func TestReportView_getPreviousBalance(t *testing.T) {
 			expectedBalance:      0,
 		},
 		"GivenPayslip_WhenOvertimeSaved_ThenExpectParsedValue": {
-			givenPreviousPayslip: &model.Payslip{Overtime: "2:00:00 incl holidays"},
+			givenPreviousPayslip: &model.Payslip{XOvertime: "2:00:00 incl holidays"},
 			expectedCell:         "2:00:00 incl holidays",
 			expectedBalance:      mustParseDuration(t, "2h"),
 		},
 		"GivenPayslip_WhenOvertimeCannotParse_ThenExpectErrorText": {
-			givenPreviousPayslip: &model.Payslip{Overtime: "2 hours"},
+			givenPreviousPayslip: &model.Payslip{XOvertime: "2 hours"},
 			expectedCell:         "<format not parseable: 2 hours>",
 			expectedBalance:      0,
 		},
@@ -93,13 +93,13 @@ func TestReportView_getNextBalance(t *testing.T) {
 			expectedBalance:      mustParseDuration(t, "2h"),
 		},
 		"GivenPayslip_WhenOvertimeSaved_ThenExpectCellValueVerbatim": {
-			givenNextPayslip:     &model.Payslip{Overtime: "2:00:00 with holidays"},
+			givenNextPayslip:     &model.Payslip{XOvertime: "2:00:00 with holidays"},
 			givenProposedBalance: mustParseDuration(t, "4h"),
 			expectedCell:         "2:00:00 with holidays",
 			expectedBalance:      mustParseDuration(t, "2h"),
 		},
 		"GivenPayslip_WhenOvertimeCannotParse_ThenExpectErrorTextAndUnchangedProposedBalance": {
-			givenNextPayslip:     &model.Payslip{Overtime: "2 hours"},
+			givenNextPayslip:     &model.Payslip{XOvertime: "2 hours"},
 			givenProposedBalance: mustParseDuration(t, "4h"),
 			expectedCell:         "<format not parseable: 2 hours>",
 			expectedBalance:      mustParseDuration(t, "4h"),
@@ -137,7 +137,7 @@ func TestReportView_getOvertimeBalanceEditPreview(t *testing.T) {
 			expectedOvertimeBalanceEditPreview: "2:00:00",
 		},
 		"GivenNoPayslip_WhenOvertimeExists_ThenUseExistingValue": {
-			givenNextPayslip:                   &model.Payslip{Overtime: "2:00:00"},
+			givenNextPayslip:                   &model.Payslip{XOvertime: "2:00:00"},
 			givenProposedBalance:               mustParseDuration(t, "4h"),
 			expectedOvertimeBalanceEditPreview: "2:00:00",
 		},

--- a/pkg/web/employeereport/update_payslip_controller.go
+++ b/pkg/web/employeereport/update_payslip_controller.go
@@ -74,7 +74,7 @@ func (c *UpdatePayslipController) fetchNextPayslip(ctx context.Context) error {
 
 func (c *UpdatePayslipController) savePayslip(ctx context.Context) error {
 	payslip := c.NextPayslip
-	payslip.Overtime = c.Input.Overtime
+	payslip.XOvertime = c.Input.Overtime
 	err := c.OdooClient.UpdatePayslip(ctx, payslip)
 	if err != nil {
 		return err

--- a/pkg/web/overtimereport/monthlyreport_view.go
+++ b/pkg/web/overtimereport/monthlyreport_view.go
@@ -68,7 +68,8 @@ func (v *reportView) GetValuesForMonthlyReport(report timesheet.Report, previous
 			"NextMonthLink":     fmt.Sprintf(linkFormat, report.Employee.ID, nextYear, nextMonth),
 			"PreviousMonthLink": fmt.Sprintf(linkFormat, report.Employee.ID, prevYear, prevMonth),
 		},
-		"Username":         report.Employee.Name,
-		"MonthDisplayName": fmt.Sprintf("%s %d", report.From.Month(), report.From.Year()),
+		"Username":            report.Employee.Name,
+		"MonthDisplayName":    fmt.Sprintf("%s %d", report.From.Month(), report.From.Year()),
+		"TimezoneDisplayName": report.From.Location().String(),
 	}
 }

--- a/pkg/web/overtimereport/overtimereport_controller.go
+++ b/pkg/web/overtimereport/overtimereport_controller.go
@@ -40,11 +40,11 @@ func (c *ReportController) DisplayOvertimeReport() error {
 	root.WithSteps(
 		root.NewStep("parse user input", c.parseInput),
 		root.NewStep("fetch employee", c.fetchEmployeeByID),
+		root.NewStep("fetch payslips", c.fetchPayslips),
 		root.NewStep("fetch user settings", c.fetchUser),
 		root.NewStep("fetch contracts", c.fetchContracts),
 		root.NewStep("fetch attendances", c.fetchAttendances),
 		root.NewStep("fetch leaves", c.fetchLeaves),
-		root.NewStep("fetch payslips", c.fetchPayslips),
 		root.When(pipeline.Not(c.noMonthGiven), "calculate monthly report", c.calculateMonthlyReport),
 		root.When(c.noMonthGiven, "calculate yearly report", c.calculateYearlyReport),
 	)
@@ -87,31 +87,49 @@ func (c *ReportController) fetchContracts(ctx context.Context) error {
 }
 
 func (c *ReportController) fetchAttendances(ctx context.Context) error {
+	tz := c.getTimeZone()
 	begin, end := c.Input.GetDateRange()
-	attendances, err := c.OdooClient.FetchAttendancesBetweenDates(ctx, c.Employee.ID, begin, end)
-	c.Attendances = attendances.AddCurrentTimeAsSignOut()
+	attendances, err := c.OdooClient.FetchAttendancesBetweenDates(ctx, c.Employee.ID, begin.In(tz), end.In(tz))
+	c.Attendances = attendances.AddCurrentTimeAsSignOut(tz)
 	return err
 }
 
 func (c *ReportController) fetchLeaves(ctx context.Context) error {
+	tz := c.getTimeZone()
 	begin, end := c.Input.GetDateRange()
-	leaves, err := c.OdooClient.FetchLeavesBetweenDates(ctx, c.Employee.ID, begin, end)
+	leaves, err := c.OdooClient.FetchLeavesBetweenDates(ctx, c.Employee.ID, begin.In(tz), end.In(tz))
 	c.Leaves = leaves
 	return err
 }
 
 func (c *ReportController) calculateMonthlyReport(_ context.Context) error {
-	start := time.Date(c.Input.Year, time.Month(c.Input.Month), 1, 0, 0, 0, 0, time.UTC)
+	tz := c.getTimeZone()
+	start := time.Date(c.Input.Year, time.Month(c.Input.Month), 1, 0, 0, 0, 0, tz)
 	end := start.AddDate(0, 1, 0)
 	reporter := timesheet.NewReporter(c.Attendances, c.Leaves, c.Employee, c.Contracts).
 		SetRange(start, end).
-		SetTimeZone(c.User.TimeZone.Location())
+		SetTimeZone(tz)
+
 	report, err := reporter.CalculateReport()
 	if err != nil {
 		return err
 	}
 	values := c.ReportView.GetValuesForMonthlyReport(report, c.PreviousPayslip, c.NextPayslip)
 	return c.Echo.Render(http.StatusOK, monthlyReportTemplateName, values)
+}
+
+func (c *ReportController) getTimeZone() *time.Location {
+	if c.NextPayslip != nil && c.NextPayslip.TimeZone != nil {
+		// timezone from payslip has precedence.
+		return c.NextPayslip.TimeZone.Location()
+	}
+	if c.User != nil && c.SessionData.Employee.ID == c.Employee.ID && time.Now().Month() == time.Month(c.Input.Month) {
+		// get the timezone from user preferences only if we create a report for our own user AND we're in the current month.
+		// for months long in the past we don't want to calculate based on user's current preferences.
+		return c.User.TimeZone.Location()
+	}
+	// last resort to default TZ.
+	return controller.DefaultTimeZone
 }
 
 func (c *ReportController) calculateYearlyReport(_ context.Context) error {

--- a/pkg/web/overtimereport/overtimereport_controller.go
+++ b/pkg/web/overtimereport/overtimereport_controller.go
@@ -119,14 +119,14 @@ func (c *ReportController) calculateMonthlyReport(_ context.Context) error {
 }
 
 func (c *ReportController) getTimeZone() *time.Location {
-	if c.NextPayslip != nil && c.NextPayslip.TimeZone != nil {
+	if c.NextPayslip != nil && !c.NextPayslip.TimeZone.IsEmpty() {
 		// timezone from payslip has precedence.
 		return c.NextPayslip.TimeZone.Location()
 	}
 	if c.User != nil && c.SessionData.Employee.ID == c.Employee.ID && time.Now().Month() == time.Month(c.Input.Month) {
 		// get the timezone from user preferences only if we create a report for our own user AND we're in the current month.
 		// for months long in the past we don't want to calculate based on user's current preferences.
-		return c.User.TimeZone.Location()
+		return c.User.TimeZone.LocationOrDefault(controller.DefaultTimeZone)
 	}
 	// last resort to default TZ.
 	return controller.DefaultTimeZone

--- a/pkg/web/reportconfig/config_controller.go
+++ b/pkg/web/reportconfig/config_controller.go
@@ -124,9 +124,10 @@ func (c *ConfigController) fetchUser(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	tz := user.TimeZone.LocationOrDefault(controller.DefaultTimeZone)
 	c.User = user
-	c.StartOfWeek = c.StartOfWeek.In(user.TimeZone.Location())
-	c.EndOfWeek = c.EndOfWeek.In(user.TimeZone.Location())
+	c.StartOfWeek = c.StartOfWeek.In(tz)
+	c.EndOfWeek = c.EndOfWeek.In(tz)
 	return nil
 }
 

--- a/pkg/web/reportconfig/config_controller.go
+++ b/pkg/web/reportconfig/config_controller.go
@@ -40,8 +40,8 @@ func (c *ConfigController) ShowConfigurationFormAndWeeklyReport() error {
 	root.WithSteps(
 		root.NewStep("parse user input", c.parseInput),
 		root.WithNestedSteps("weekly report", pipeline.Bool[context.Context](true),
-			root.NewStep("fetch attendances", c.fetchAttendanceOfCurrentWeek),
 			root.NewStep("fetch user", c.fetchUser),
+			root.NewStep("fetch attendances", c.fetchAttendanceOfCurrentWeek),
 			root.NewStep("fetch contracts", c.fetchContracts),
 			root.NewStep("fetch leaves", c.fetchLeaves),
 			root.NewStep("calculate report", c.calculateReport),
@@ -116,7 +116,7 @@ func (c *ConfigController) fetchAttendanceOfCurrentWeek(ctx context.Context) err
 	attendances.SortByDate()
 	c.Attendances = attendances.
 		FilterAttendanceBetweenDates(c.StartOfWeek, c.EndOfWeek).
-		AddCurrentTimeAsSignOut()
+		AddCurrentTimeAsSignOut(c.User.TimeZone.Location())
 	return nil
 }
 

--- a/templates/help.html
+++ b/templates/help.html
@@ -56,6 +56,22 @@
 </div>
 
 <div>
+    <h3>Timezones</h3>
+    <p>
+        Odootools needs to know if the <strong>majority</strong> of attendances within a month is logged outside "Europe/Zurich" timezone.
+        For the current month, the user needs to update their timezone settings in user preferences in Odoo, for example "America/Vancouver".
+        For past months, the timezone needs to be saved in the according payslip.
+        This is done by PeopleOps when they create the payslips for all employees.
+    </p>
+    <p>
+        The timezone is saved in the payslip in order to get a historic view, for example when creating a yearly report, when only certain months differ from the default timezone.
+    </p>
+    <p>
+        If there are attendances in multiple timezones within a month, then the attendances of the minority timezones need to be saved in Odoo in the main timezone of the affected month.
+    </p>
+</div>
+
+<div>
     <h3>Overtime balance and Payslip</h3>
      <p>
         The overtime balance is calculated with following formula:

--- a/templates/overtimereport-monthly.html
+++ b/templates/overtimereport-monthly.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-<h1>Attendance for {{ .Username }}<small class="text-muted"> {{ .MonthDisplayName }}</small></h1>
+<h1>Attendance for {{ .Username }}<small class="text-muted"> {{ .MonthDisplayName }}, {{ .TimezoneDisplayName }}</small></h1>
 <div class="float"></div>
 {{ with .Error }}
 <div class="alert alert-danger" role="alert">{{ . }}</div>

--- a/web_command.go
+++ b/web_command.go
@@ -1,12 +1,22 @@
 package main
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/urfave/cli/v2"
 	"github.com/vshn/odootools/pkg/odoo"
 	"github.com/vshn/odootools/pkg/web"
+	"github.com/vshn/odootools/pkg/web/controller"
 )
 
 func RunWebServer(cli *cli.Context) error {
+
+	loc, err := time.LoadLocation(cli.String(newDefaultTimezoneFlag().Name))
+	if err != nil {
+		return fmt.Errorf("cannot load timezone: %w", err)
+	}
+	controller.DefaultTimeZone = loc
 
 	client, err := odoo.NewClient(cli.String(newOdooURLFlag().Name), odoo.ClientOptions{UseDebugLogger: cli.Int(newLogLevelFlag().Name) >= 2})
 	if err != nil {
@@ -34,6 +44,7 @@ func newWebCommand() *cli.Command {
 		Flags: []cli.Flag{
 			newSecretKeyFlag(),
 			newListenAddress(),
+			newDefaultTimezoneFlag(),
 			newTLSCertFlag(),
 			newTLSKeyFlag(),
 		},


### PR DESCRIPTION
## Summary

With this change, the weekly and monthly report now calculate and show the times in the timezone of the employee.
The timezone information can come from different sources, according to preference:
- From the payslip (added by PeopleOps)
- From the user preferences (only for own report in the current month)
- Default of Europe/Zurich (changeable by CLI flag)

The yearly report will be updated in a later PR.

See also #120 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update the documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
