### PR TITLE
Fix saving timezone when updating a payslip

### DIFF
--- a/pkg/odoo/timezone.go
+++ b/pkg/odoo/timezone.go
@@ -27,6 +27,14 @@ func (tz *TimeZone) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// MarshalJSON implements json.Marshaler.
+func (tz *TimeZone) MarshalJSON() ([]byte, error) {
+	if tz.IsEmpty() || tz.Location() == time.Local {
+		return []byte(`null`), nil
+	}
+	return []byte(fmt.Sprintf(`"%s"`, tz.loc)), nil
+}
+
 func (tz *TimeZone) Location() *time.Location {
 	if tz == nil {
 		return nil

--- a/pkg/odoo/timezone_test.go
+++ b/pkg/odoo/timezone_test.go
@@ -35,6 +35,30 @@ func TestTimeZone_UnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestTimeZone_MarshalJSON(t *testing.T) {
+	tests := map[string]struct {
+		givenLocation  *time.Location
+		expectedOutput []byte
+	}{
+		"nil":          {givenLocation: nil, expectedOutput: []byte("null")},
+		"EuropeZurich": {givenLocation: mustLoadLocation("Europe/Zurich"), expectedOutput: []byte(`"Europe/Zurich"`)},
+		"Local":        {givenLocation: time.Local, expectedOutput: []byte("null")}, // "Local" isn't recognized by Odoo
+		"UTC":          {givenLocation: time.UTC, expectedOutput: []byte(`"UTC"`)},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			subject := &TimeZone{loc: tt.givenLocation}
+			result, err := subject.MarshalJSON()
+			require.NoError(t, err)
+			if tt.expectedOutput == nil {
+				assert.Nil(t, result)
+			} else {
+				assert.Equal(t, tt.expectedOutput, result)
+			}
+		})
+	}
+}
+
 func mustLoadLocation(name string) *time.Location {
 	loc, err := time.LoadLocation(name)
 	if err != nil {


### PR DESCRIPTION


## Summary

Without MarshalJSON for TimeZone, then the field gets serialized as "{}", which Odoo accepts and then  also returns this when querying again, causing UnmarshalJSON of the TimeZone to fail again.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
