### PR TITLE
Fix payslip saves

### DIFF
--- a/pkg/odoo/date.go
+++ b/pkg/odoo/date.go
@@ -3,6 +3,7 @@ package odoo
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"time"
 )
 
@@ -28,7 +29,7 @@ func (d *Date) MarshalJSON() ([]byte, error) {
 	if d.IsZero() {
 		return []byte("false"), nil
 	}
-	return []byte(d.Format(DateTimeFormat)), nil
+	return []byte(fmt.Sprintf(`"%s"`, d.Format(DateTimeFormat))), nil
 }
 
 func (d *Date) UnmarshalJSON(b []byte) error {

--- a/pkg/odoo/date_test.go
+++ b/pkg/odoo/date_test.go
@@ -52,7 +52,7 @@ func TestDate_MarshalJSON(t *testing.T) {
 		},
 		"GivenTime_ThenReturnFormatted": {
 			givenDate:      Date{Time: time.Date(2021, 02, 03, 4, 5, 6, 0, time.UTC)},
-			expectedOutput: "2021-02-03 04:05:06",
+			expectedOutput: `"2021-02-03 04:05:06"`,
 		},
 	}
 	for name, tc := range tests {


### PR DESCRIPTION
## Summary

Fixes an issue where a new value of overtime in payslip cannot be saved.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
