### PR TITLE
Show previous month's balance in monthly report

### DIFF
--- a/pkg/timesheet/balancereport.go
+++ b/pkg/timesheet/balancereport.go
@@ -9,6 +9,8 @@ import (
 
 type BalanceReport struct {
 	Report Report
+	// PreviousBalance is the definitive balance from the previous month's payslip, if given.
+	PreviousBalance time.Duration
 	// CalculatedBalance is the sum of TotalOvertime with the previous month's payslip, if given.
 	CalculatedBalance time.Duration
 	// DefinitiveBalance contains the value of the current month's payslip, if given.
@@ -31,16 +33,15 @@ func (b *BalanceReportBuilder) CalculateBalanceReport() (BalanceReport, error) {
 	r := BalanceReport{Report: b.report}
 
 	// calculated balance
-	previousBalance := time.Duration(0)
 	previousMonth := b.payslips.FilterInMonth(r.Report.From.AddDate(0, -1, 0))
 	if previousMonth != nil {
 		parsed, err := previousMonth.ParseOvertime()
 		if err != nil {
 			return r, fmt.Errorf("cannot parse overtime of payslip '%s': %w", previousMonth.Name, err)
 		}
-		previousBalance = parsed
+		r.PreviousBalance = parsed
 	}
-	r.CalculatedBalance = previousBalance + r.Report.Summary.TotalOvertime
+	r.CalculatedBalance = r.PreviousBalance + r.Report.Summary.TotalOvertime
 
 	// definitive balance
 	currentMonth := b.payslips.FilterInMonth(r.Report.From.AddDate(0, 0, 1)) // add a day to cover timezone offsets

--- a/pkg/web/overtimereport/monthlyreport_view.go
+++ b/pkg/web/overtimereport/monthlyreport_view.go
@@ -50,6 +50,7 @@ func (v *monthlyReportView) formatMonthlySummary(report timesheet.BalanceReport)
 		"TotalWorked":   v.FormatDurationInHours(s.TotalWorkedTime),
 		"TotalExcused":  v.FormatDurationInHours(s.TotalExcusedTime),
 	}
+	val["PreviousBalance"] = v.FormatDurationInHours(report.PreviousBalance)
 	val["NewOvertimeBalance"] = v.FormatDurationInHours(report.CalculatedBalance)
 	val["CurrentPayslipBalance"] = ""
 	if report.DefinitiveBalance != nil {

--- a/templates/overtimereport-monthly.html
+++ b/templates/overtimereport-monthly.html
@@ -58,7 +58,7 @@
         <th scope="col"></th>
         <th scope="col"></th>
         <th scope="col"></th>
-        <th scope="col"></th>
+        <th scope="col">Previous Month's Balance</th>
         <th scope="col">Calculated Balance</th>
         <th scope="col">Definitive Balance</th>
     </tr>
@@ -67,7 +67,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td></td>
+        <td>{{ .Summary.PreviousBalance }}</td>
         <td>{{ .Summary.NewOvertimeBalance }}</td>
         <td>{{ .Summary.CurrentPayslipBalance }}</td>
     </tr>


### PR DESCRIPTION
## Summary

This change will now display the previous month overtime in a monthly report, so that switching between reports is not necessary anymore.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update the documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
