### PR TITLE
Fix leaves and excused times in monthly report

### DIFF
--- a/pkg/odoo/date.go
+++ b/pkg/odoo/date.go
@@ -61,6 +61,12 @@ func IsWithinTimeRange(date, from, to time.Time) bool {
 	return isBetween || date.Unix() == from.Unix() || date.Unix() == to.Unix()
 }
 
+// LocalizeTime returns the same time but with a different location.
+// As opposed to time.In(loc), the returned time is not just updated with the location.
+func LocalizeTime(tm time.Time, loc *time.Location) time.Time {
+	return time.Date(tm.Year(), tm.Month(), tm.Day(), tm.Hour(), tm.Minute(), tm.Second(), tm.Nanosecond(), loc)
+}
+
 // MustParseDateTime parses the given value in DateTimeFormat or panics if it fails.
 func MustParseDateTime(value string) Date {
 	tm, err := ParseDateTime(value)

--- a/pkg/odoo/model/leave_test.go
+++ b/pkg/odoo/model/leave_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,9 +18,16 @@ func TestLeave_SplitByDay(t *testing.T) {
 			Type:     &LeaveType{ID: 1, Name: "SomeType"},
 			State:    "validated",
 		}
+		expectedLeave := Leave{
+			ID:       1,
+			DateFrom: odoo.NewDate(2021, 02, 03, 0, 0, 0, time.UTC),
+			DateTo:   odoo.NewDate(2021, 02, 03, 23, 59, 59, time.UTC),
+			Type:     &LeaveType{ID: 1, Name: "SomeType"},
+			State:    "validated",
+		}
 		result := givenLeave.SplitByDay()
 		require.Len(t, result, 1)
-		assert.Equal(t, givenLeave, result[0])
+		assert.Equal(t, expectedLeave, result[0])
 	})
 
 	tests := map[string]struct {
@@ -31,8 +39,8 @@ func TestLeave_SplitByDay(t *testing.T) {
 				DateFrom: odoo.MustParseDateTime("2021-02-03 07:00:00"), DateTo: odoo.MustParseDateTime("2021-02-04 19:00:00"),
 			},
 			expectedLeaves: []Leave{
-				{DateFrom: odoo.MustParseDateTime("2021-02-03 07:00:00"), DateTo: odoo.MustParseDateTime("2021-02-03 15:00:00")},
-				{DateFrom: odoo.MustParseDateTime("2021-02-04 07:00:00"), DateTo: odoo.MustParseDateTime("2021-02-04 15:00:00")},
+				{DateFrom: odoo.MustParseDateTime("2021-02-03 00:00:00"), DateTo: odoo.MustParseDateTime("2021-02-03 23:59:59")},
+				{DateFrom: odoo.MustParseDateTime("2021-02-04 00:00:00"), DateTo: odoo.MustParseDateTime("2021-02-04 23:59:59")},
 			},
 		},
 	}

--- a/pkg/timesheet/dailysummary.go
+++ b/pkg/timesheet/dailysummary.go
@@ -87,9 +87,13 @@ func (s OvertimeSummary) WorkingTime() time.Duration {
 	return s.RegularWorkingTime + time.Duration(overtime)
 }
 
-// ExcusedTime returns the sum of AuthoritiesTime, PublicServiceTime and SickLeaveTime.
+// ExcusedTime returns the sum of AuthoritiesTime, PublicServiceTime and SickLeaveTime, but it can't exceed DailyMax.
 func (s OvertimeSummary) ExcusedTime() time.Duration {
-	return s.AuthoritiesTime + s.PublicServiceTime + s.SickLeaveTime
+	sum := s.AuthoritiesTime + s.PublicServiceTime + s.SickLeaveTime
+	if sum >= s.DailyMax {
+		return s.DailyMax
+	}
+	return sum
 }
 
 // calculateDailyMax returns the theoretical amount of hours that an employee should work on this day.
@@ -173,7 +177,7 @@ func (s *DailySummary) IsWeekend() bool {
 
 func findDailySummaryByDate(dailies []*DailySummary, date time.Time) (*DailySummary, bool) {
 	for _, daily := range dailies {
-		if daily.Date.Day() == date.Day() {
+		if daily.Date.Day() == date.Day() && daily.Date.Month() == date.Month() && daily.Date.Year() == date.Year() {
 			return daily, true
 		}
 	}

--- a/pkg/timesheet/report.go
+++ b/pkg/timesheet/report.go
@@ -251,8 +251,12 @@ func (r *ReportBuilder) filterLeavesInTimeRange() []model.Leave {
 	for _, leave := range r.leaves.Items {
 		splits := leave.SplitByDay()
 		for _, split := range splits {
-			date := split.DateFrom.In(r.getTimeZone())
+			tz := r.getTimeZone()
+			from := split.DateFrom
+			date := time.Date(from.Year(), from.Month(), from.Day(), 0, 0, 0, 0, tz)
 			if odoo.IsWithinTimeRange(date, r.from, r.to) && date.Weekday() != time.Sunday && date.Weekday() != time.Saturday {
+				split.DateFrom.Time = odoo.LocalizeTime(split.DateFrom.Time, tz)
+				split.DateTo.Time = odoo.LocalizeTime(split.DateTo.Time, tz)
 				filteredLeaves = append(filteredLeaves, split)
 			}
 		}

--- a/pkg/timesheet/yearly_report.go
+++ b/pkg/timesheet/yearly_report.go
@@ -50,7 +50,7 @@ func (r *YearlyReportBuilder) CalculateYearlyReport() (YearlyReport, error) {
 		max = int(now.Month())
 	}
 	min := 1
-	if startDate, found := r.getEarliestStartContractDate(); found && startDate.Year() == now.Year() && r.year == now.Year() {
+	if startDate, found := r.getEarliestStartContractDate(); found && startDate.Year() == r.year {
 		min = int(startDate.Month())
 	}
 

--- a/pkg/web/overtimereport/monthlyreport_controller.go
+++ b/pkg/web/overtimereport/monthlyreport_controller.go
@@ -93,7 +93,7 @@ func (c *MonthlyReportController) getTimeZone() *time.Location {
 
 func (c *MonthlyReportController) fetchPayslips(ctx context.Context) error {
 	lastMonth := c.Input.GetFirstDayOfMonth().AddDate(0, -1, -1)
-	currentMonth := lastMonth.AddDate(0, 2, 1)
+	currentMonth := lastMonth.AddDate(0, 2, 2)
 	payslips, err := c.OdooClient.FetchPayslipBetween(ctx, c.Employee.ID, lastMonth, currentMonth)
 	c.Payslips = payslips
 	return err


### PR DESCRIPTION
## Summary

* Leaves didn't correctly respect timezones.
* Reported excused time could actually exceed the daily max time, now they are capped.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update the documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
