### PR TITLE
Fix contract start

### DIFF
--- a/pkg/odoo/model/contract.go
+++ b/pkg/odoo/model/contract.go
@@ -3,6 +3,7 @@ package model
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/vshn/odootools/pkg/odoo"
@@ -60,6 +61,15 @@ func (l ContractList) GetFTERatioForDay(date time.Time) (float64, error) {
 		Err:  fmt.Errorf("no contract found that covers date: %s", date),
 		Date: date,
 	}
+}
+
+// Sort sorts the contracts
+func (l ContractList) Sort() {
+	sort.Slice(l.Items, func(i, j int) bool {
+		a := l.Items[i]
+		b := l.Items[j]
+		return a.Start.Before(b.Start.Time)
+	})
 }
 
 func (o Odoo) FetchAllContractsOfEmployee(ctx context.Context, employeeID int) (ContractList, error) {

--- a/pkg/odoo/model/contract.go
+++ b/pkg/odoo/model/contract.go
@@ -72,6 +72,22 @@ func (l ContractList) Sort() {
 	})
 }
 
+// GetEarliestStartContractDate gets the date where the first contract is valid from.
+// Returns time.Time{} if no contract has a start date.
+func (l ContractList) GetEarliestStartContractDate() time.Time {
+	now := time.Now()
+	start := now
+	for _, contract := range l.Items {
+		if contract.Start.Before(start) {
+			start = contract.Start.Time
+		}
+	}
+	if start.Equal(now) {
+		return time.Time{}
+	}
+	return start
+}
+
 func (o Odoo) FetchAllContractsOfEmployee(ctx context.Context, employeeID int) (ContractList, error) {
 	return o.readContracts(ctx, []odoo.Filter{
 		[]interface{}{"employee_id", "=", employeeID},

--- a/pkg/odoo/model/contract_test.go
+++ b/pkg/odoo/model/contract_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"math/rand"
 	"strconv"
 	"testing"
 	"time"
@@ -86,6 +87,66 @@ func TestContractList_GetFTERatioForDay(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedRatio, result)
+		})
+	}
+}
+
+func TestContractList_Sort(t *testing.T) {
+	tests := map[string]struct {
+		givenContracts ContractList
+		expectedOrder  ContractList
+	}{
+		"EmptyList": {
+			givenContracts: ContractList{Items: []Contract{}},
+			expectedOrder:  ContractList{Items: []Contract{}},
+		},
+		"SingleList": {
+			givenContracts: ContractList{Items: []Contract{
+				{Start: odoo.NewDate(2021, 02, 1, 0, 0, 0, time.UTC)},
+			}},
+			expectedOrder: ContractList{Items: []Contract{
+				{Start: odoo.NewDate(2021, 02, 1, 0, 0, 0, time.UTC)},
+			}},
+		},
+		"TwoEntries": {
+			givenContracts: ContractList{Items: []Contract{
+				{Start: odoo.NewDate(2021, 02, 1, 0, 0, 0, time.UTC)},
+				{Start: odoo.NewDate(2021, 01, 1, 0, 0, 0, time.UTC), End: odoo.NewDate(2021, 01, 31, 0, 0, 0, time.UTC)},
+			}},
+			expectedOrder: ContractList{Items: []Contract{
+				{Start: odoo.NewDate(2021, 01, 1, 0, 0, 0, time.UTC), End: odoo.NewDate(2021, 01, 31, 0, 0, 0, time.UTC)},
+				{Start: odoo.NewDate(2021, 02, 1, 0, 0, 0, time.UTC)},
+			}},
+		},
+		"MultipleEntries": {
+			givenContracts: ContractList{Items: []Contract{
+				{Start: odoo.NewDate(2021, 02, 1, 0, 0, 0, time.UTC), End: odoo.NewDate(2021, 02, 28, 0, 0, 0, time.UTC)},
+				{Start: odoo.NewDate(2021, 03, 1, 0, 0, 0, time.UTC), End: odoo.NewDate(2021, 03, 31, 0, 0, 0, time.UTC)},
+				{Start: odoo.NewDate(2021, 05, 1, 0, 0, 0, time.UTC)},
+				{Start: odoo.NewDate(2021, 04, 1, 0, 0, 0, time.UTC), End: odoo.NewDate(2021, 04, 30, 0, 0, 0, time.UTC)},
+				{Start: odoo.NewDate(2021, 01, 1, 0, 0, 0, time.UTC), End: odoo.NewDate(2021, 01, 31, 0, 0, 0, time.UTC)},
+			}},
+			expectedOrder: ContractList{Items: []Contract{
+				{Start: odoo.NewDate(2021, 01, 1, 0, 0, 0, time.UTC), End: odoo.NewDate(2021, 01, 31, 0, 0, 0, time.UTC)},
+				{Start: odoo.NewDate(2021, 02, 1, 0, 0, 0, time.UTC), End: odoo.NewDate(2021, 02, 28, 0, 0, 0, time.UTC)},
+				{Start: odoo.NewDate(2021, 03, 1, 0, 0, 0, time.UTC), End: odoo.NewDate(2021, 03, 31, 0, 0, 0, time.UTC)},
+				{Start: odoo.NewDate(2021, 04, 1, 0, 0, 0, time.UTC), End: odoo.NewDate(2021, 04, 30, 0, 0, 0, time.UTC)},
+				{Start: odoo.NewDate(2021, 05, 1, 0, 0, 0, time.UTC)},
+			}},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// randomize each list a few times, should always return same stable order.
+			for i := 0; i < 5; i++ {
+				rand.Seed(time.Now().UnixNano())
+				rand.Shuffle(len(tc.givenContracts.Items), func(i, j int) {
+					tc.givenContracts.Items[i], tc.givenContracts.Items[j] = tc.givenContracts.Items[j], tc.givenContracts.Items[i]
+				})
+
+				tc.givenContracts.Sort()
+				assert.Equalf(t, tc.expectedOrder.Items, tc.givenContracts.Items, "attempt %d", i)
+			}
 		})
 	}
 }

--- a/pkg/odoo/model/contract_test.go
+++ b/pkg/odoo/model/contract_test.go
@@ -150,3 +150,34 @@ func TestContractList_Sort(t *testing.T) {
 		})
 	}
 }
+
+func TestReportBuilder_getEarliestStartContractDate(t *testing.T) {
+	tests := map[string]struct {
+		givenContracts ContractList
+		expectedDate   time.Time
+	}{
+		"EmptyList": {
+			givenContracts: ContractList{Items: []Contract{}},
+			expectedDate:   time.Time{},
+		},
+		"SingleContract_ThenReturnStart": {
+			givenContracts: ContractList{Items: []Contract{
+				{Start: odoo.MustParseDateTime("2021-02-04 08:00:00")},
+			}},
+			expectedDate: odoo.MustParseDateTime("2021-02-04 08:00:00").Time,
+		},
+		"MultipleContracts_ThenReturnEarliest": {
+			givenContracts: ContractList{Items: []Contract{
+				{Start: odoo.MustParseDate("2021-03-01")},
+				{Start: odoo.MustParseDate("2021-02-04"), End: odoo.MustParseDate("2021-02-28")},
+			}},
+			expectedDate: odoo.MustParseDate("2021-02-04").Time,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			resultDate := tt.givenContracts.GetEarliestStartContractDate()
+			assert.Equal(t, tt.expectedDate, resultDate)
+		})
+	}
+}

--- a/pkg/timesheet/report.go
+++ b/pkg/timesheet/report.go
@@ -204,17 +204,22 @@ func (r *ReportBuilder) prepareDays() ([]*DailySummary, error) {
 	firstDay := r.from
 	lastDay := r.to
 
-	now := r.clock().In(r.getTimeZone())
+	tz := r.getTimeZone()
+	now := r.clock().In(tz)
 	if r.clampToNow && lastDay.After(now) {
 		lastDay = r.getDateTomorrow()
 	}
 
+	contractStartDate := odoo.LocalizeTime(r.contracts.GetEarliestStartContractDate(), tz)
 	for currentDay := firstDay; currentDay.Before(lastDay); currentDay = currentDay.AddDate(0, 0, 1) {
+		if currentDay.Before(contractStartDate) {
+			continue
+		}
 		currentRatio, err := r.contracts.GetFTERatioForDay(currentDay)
 		if err != nil {
 			return days, err
 		}
-		days = append(days, NewDailySummary(currentRatio, currentDay.In(r.getTimeZone())))
+		days = append(days, NewDailySummary(currentRatio, currentDay.In(tz)))
 	}
 
 	return days, nil

--- a/pkg/timesheet/yearly_report.go
+++ b/pkg/timesheet/yearly_report.go
@@ -99,17 +99,6 @@ func makeRange(min, max int) []int {
 	return a
 }
 
-func (r *YearlyReportBuilder) getEarliestStartContractDate() (time.Time, bool) {
-	now := r.clock()
-	start := now
-	for _, contract := range r.contracts.Items {
-		if contract.Start.Before(start) {
-			start = contract.Start.Time
-		}
-	}
-	return start, start != now
-}
-
 func (r *YearlyReportBuilder) SetYear(year int) *YearlyReportBuilder {
 	r.year = year
 	return r

--- a/pkg/timesheet/yearly_report_test.go
+++ b/pkg/timesheet/yearly_report_test.go
@@ -10,36 +10,6 @@ import (
 	"github.com/vshn/odootools/pkg/odoo/model"
 )
 
-func TestReportBuilder_getEarliestStartContractDate(t *testing.T) {
-	tests := map[string]struct {
-		givenContracts model.ContractList
-		expectedDate   time.Time
-		expectedFound  bool
-	}{
-		"GivenNoContracts_ThenReturnFalse": {
-			givenContracts: model.ContractList{},
-			expectedFound:  false,
-		},
-		"GivenContracts_WhenStartDateExists_ThenReturnTrue": {
-			givenContracts: model.ContractList{Items: []model.Contract{
-				{Start: odoo.MustParseDateTime("2021-02-04 08:00:00")},
-			}},
-			expectedDate:  odoo.MustParseDateTime("2021-02-04 08:00:00").Time,
-			expectedFound: true,
-		},
-	}
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			r := NewYearlyReporter(model.AttendanceList{}, odoo.List[model.Leave]{}, model.Employee{}, tt.givenContracts, model.PayslipList{})
-			resultDate, found := r.getEarliestStartContractDate()
-			assert.Equal(t, tt.expectedFound, found)
-			if tt.expectedFound {
-				assert.Equal(t, tt.expectedDate, resultDate)
-			}
-		})
-	}
-}
-
 func TestYearlyReportBuilder_CalculateYearlyReport(t *testing.T) {
 	t.Skipf("test fails, needs more investigation")
 	DefaultTimeZone = zurichTZ


### PR DESCRIPTION
## Summary

* Fixes an issue where the monthly report would fail if the first day in a contract doesn't start at the beginning of the month. Now it's possible.
* Fixes an issue where the yearly report would fail if the contract doesn't start in 1st of january, now partial reports are possible.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update the documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
