### PR TITLE
Timesheet Validation

### DIFF
--- a/pkg/odoo/model/attendance.go
+++ b/pkg/odoo/model/attendance.go
@@ -92,7 +92,7 @@ func (l AttendanceList) FilterAttendanceBetweenDates(from, to time.Time) Attenda
 }
 
 // AddCurrentTimeAsSignOut adds an Attendance with timesheet.ActionSignOut reason and with the current time.
-// An attendance is only added if the last Attendance in the list is timesheet.ActionSignIn.
+// An attendance is only added if the last Attendance in the list is ActionSignIn.
 func (l AttendanceList) AddCurrentTimeAsSignOut(tz *time.Location) AttendanceList {
 	if len(l.Items) == 0 {
 		return l

--- a/pkg/odoo/model/attendance.go
+++ b/pkg/odoo/model/attendance.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"time"
 
@@ -27,6 +28,11 @@ type Attendance struct {
 
 type AttendanceList odoo.List[Attendance]
 
+// String implements fmt.Stringer.
+func (a Attendance) String() string {
+	return fmt.Sprintf("Attendance ID:%d, DateTime:%q, Action:%s, Reason:%q", a.ID, a.DateTime, a.Action, a.Reason)
+}
+
 // FetchAttendancesBetweenDates retrieves all attendances associated with the given employee between 2 dates (inclusive each).
 func (o Odoo) FetchAttendancesBetweenDates(ctx context.Context, employeeID int, begin, end time.Time) (AttendanceList, error) {
 	return o.fetchAttendances(ctx, []odoo.Filter{
@@ -45,15 +51,27 @@ func (o Odoo) fetchAttendances(ctx context.Context, domainFilters []odoo.Filter)
 		Limit:  0,
 		Offset: 0,
 	}, &result)
-	result.SortByDate()
+	result.Sort()
 	return result, err
 }
 
-// SortByDate sorts the attendances by date ascending (oldest first).
-func (l AttendanceList) SortByDate() {
-	items := l.Items
+// Sort sorts the attendances by date ascending (oldest first).
+// Dates are compared by Unix time (ignoring nanoseconds).
+// If two attendances have the same date then they're sorted by Attendance.Action.
+func (l AttendanceList) Sort() {
 	sort.Slice(l.Items, func(i, j int) bool {
-		return items[i].DateTime.Unix() < items[j].DateTime.Unix()
+		a := l.Items[i]
+		b := l.Items[j]
+		if a.DateTime.Unix() != b.DateTime.Unix() {
+			// normal case with different dates
+			return a.DateTime.Unix() < b.DateTime.Unix()
+		}
+		if a.Action == b.Action {
+			// should normally not occur, it would be a duplicate signing in/out at the same time.
+			return a.Reason.String() < b.Reason.String()
+		}
+		// if at the same time, we sign_out first, then sign_in.
+		return a.Action == ActionSignOut && b.Action == ActionSignIn
 	})
 }
 

--- a/pkg/odoo/model/attendance_test.go
+++ b/pkg/odoo/model/attendance_test.go
@@ -51,11 +51,15 @@ func TestAttendanceList_Sort(t *testing.T) {
 				Items: []Attendance{
 					{DateTime: odoo.MustParseDateTime("2022-03-31 08:00:00"), Reason: &ActionReason{Name: ""}, Action: ActionSignIn},
 					{DateTime: odoo.MustParseDateTime("2022-03-31 10:00:00"), Reason: &ActionReason{Name: "AReason"}, Action: ActionSignIn},
+					{DateTime: odoo.MustParseDateTime("2022-03-31 16:00:00"), Reason: &ActionReason{Name: ""}, Action: ActionSignIn},
 					{DateTime: odoo.MustParseDateTime("2022-03-31 11:00:00"), Reason: &ActionReason{Name: "BReason"}, Action: ActionSignIn},
 					{DateTime: odoo.MustParseDateTime("2022-03-31 11:00:00"), Reason: &ActionReason{Name: "AReason"}, Action: ActionSignOut},
 					{DateTime: odoo.MustParseDateTime("2022-03-31 10:00:00"), Reason: &ActionReason{Name: ""}, Action: ActionSignOut},
 					{DateTime: odoo.MustParseDateTime("2022-03-31 12:00:00"), Reason: &ActionReason{Name: ""}, Action: ActionSignIn},
+					{DateTime: odoo.MustParseDateTime("2022-03-31 14:00:00"), Reason: &ActionReason{Name: ""}, Action: ActionSignIn},
 					{DateTime: odoo.MustParseDateTime("2022-03-31 12:00:00"), Reason: &ActionReason{Name: "BReason"}, Action: ActionSignOut},
+					{DateTime: odoo.MustParseDateTime("2022-04-01 00:00:00"), Reason: &ActionReason{Name: ""}, Action: ActionSignIn},
+					{DateTime: odoo.MustParseDateTime("2022-04-01 00:00:00"), Reason: &ActionReason{Name: ""}, Action: ActionSignOut},
 				},
 			},
 			expectedOrder: []Attendance{
@@ -66,6 +70,10 @@ func TestAttendanceList_Sort(t *testing.T) {
 				{DateTime: odoo.MustParseDateTime("2022-03-31 11:00:00"), Reason: &ActionReason{Name: "BReason"}, Action: ActionSignIn},
 				{DateTime: odoo.MustParseDateTime("2022-03-31 12:00:00"), Reason: &ActionReason{Name: "BReason"}, Action: ActionSignOut},
 				{DateTime: odoo.MustParseDateTime("2022-03-31 12:00:00"), Reason: &ActionReason{Name: ""}, Action: ActionSignIn},
+				{DateTime: odoo.MustParseDateTime("2022-03-31 14:00:00"), Reason: &ActionReason{Name: ""}, Action: ActionSignIn},
+				{DateTime: odoo.MustParseDateTime("2022-03-31 16:00:00"), Reason: &ActionReason{Name: ""}, Action: ActionSignIn},
+				{DateTime: odoo.MustParseDateTime("2022-04-01 00:00:00"), Reason: &ActionReason{Name: ""}, Action: ActionSignOut},
+				{DateTime: odoo.MustParseDateTime("2022-04-01 00:00:00"), Reason: &ActionReason{Name: ""}, Action: ActionSignIn},
 			},
 		},
 		"GivenNilList_ThenDoNothing": {

--- a/pkg/timesheet/dailysummary_test.go
+++ b/pkg/timesheet/dailysummary_test.go
@@ -22,60 +22,60 @@ func TestDailySummary_CalculateOvertime(t *testing.T) {
 			givenShifts: []AttendanceShift{
 				newAttendanceShift(hours(t, weekday, "09:00"), hours(t, weekday, "18:00"), ""),
 			},
-			expectedOvertime: hoursDuration(t, 1),
+			expectedOvertime: 1 * time.Hour,
 		},
 		"GivenMultipleShifts_WhenMoreThanDailyMax_ThenReturnOvertime": {
 			givenShifts: []AttendanceShift{
 				newAttendanceShift(hours(t, weekday, "09:00"), hours(t, weekday, "12:00"), ""),
 				newAttendanceShift(hours(t, weekday, "13:00"), hours(t, weekday, "19:00"), ""),
 			},
-			expectedOvertime: hoursDuration(t, 1),
+			expectedOvertime: 1 * time.Hour,
 		},
 		"GivenMultipleShifts_WhenLessThanDailyMax_ThenReturnUndertime": {
 			givenShifts: []AttendanceShift{
 				newAttendanceShift(hours(t, weekday, "09:00"), hours(t, weekday, "12:00"), ""),
 				newAttendanceShift(hours(t, weekday, "13:00"), hours(t, weekday, "17:00"), ""),
 			},
-			expectedOvertime: hoursDuration(t, -1),
+			expectedOvertime: -1 * time.Hour,
 		},
 		"GivenSickLeaveShifts_WhenSickLeaveIsFilling_ThenReturnZero": {
 			givenShifts: []AttendanceShift{
 				newAttendanceShift(hours(t, weekday, "09:00"), hours(t, weekday, "12:00"), ""),
 				newAttendanceShift(hours(t, weekday, "13:00"), hours(t, weekday, "18:00"), ReasonSickLeave),
 			},
-			expectedOvertime:    hoursDuration(t, 0),
-			expectedExcusedTime: hoursDuration(t, 5),
+			expectedOvertime:    0,
+			expectedExcusedTime: 5 * time.Hour,
 		},
 		"GivenSickLeaveShifts_WhenSickLeaveIsLessThanDailyMax_ThenReturnUndertime": {
 			givenShifts: []AttendanceShift{
 				newAttendanceShift(hours(t, weekday, "09:00"), hours(t, weekday, "12:00"), ""),
 				newAttendanceShift(hours(t, weekday, "13:00"), hours(t, weekday, "17:00"), ReasonSickLeave),
 			},
-			expectedOvertime:    hoursDuration(t, -1),
-			expectedExcusedTime: hoursDuration(t, 4),
+			expectedOvertime:    -1 * time.Hour,
+			expectedExcusedTime: 4 * time.Hour,
 		},
 		"GivenSickLeaveShifts_WhenCombinedHoursExceedDailyMax_ThenCapOvertime": {
 			givenShifts: []AttendanceShift{
 				newAttendanceShift(hours(t, weekday, "09:00"), hours(t, weekday, "12:00"), ""),
-				newAttendanceShift(hours(t, weekday, "13:00"), hours(t, weekday, "18:30"), ReasonSickLeave),
+				newAttendanceShift(hours(t, weekday, "13:00"), hours(t, weekday, "19:00"), ReasonSickLeave),
 			},
-			expectedOvertime:    hoursDuration(t, 0),
-			expectedExcusedTime: hoursDuration(t, 5.5),
+			expectedOvertime:    0,
+			expectedExcusedTime: 6 * time.Hour,
 		},
 		"GivenSickLeaveShifts_WhenExcusedHoursExceedDailyMax_ThenCapExcusedTime": {
 			givenShifts: []AttendanceShift{
-				{Start: hours(t, weekday, "09:00"), End: hours(t, weekday, "19:00"), Reason: ReasonSickLeave},
+				newAttendanceShift(hours(t, weekday, "09:00"), hours(t, weekday, "19:00"), ReasonSickLeave),
 			},
-			expectedOvertime:    hoursDuration(t, 0),
-			expectedExcusedTime: hoursDuration(t, 8),
+			expectedOvertime:    0,
+			expectedExcusedTime: 8 * time.Hour,
 		},
 		"GivenSickLeaveShifts_WhenWorkingHoursIsMoreThanDailyMax_ThenIgnoreSickLeaveCompletely": {
 			givenShifts: []AttendanceShift{
 				newAttendanceShift(hours(t, weekday, "09:00"), hours(t, weekday, "18:00"), ""),
 				newAttendanceShift(hours(t, weekday, "19:00"), hours(t, weekday, "20:00"), ReasonSickLeave),
 			},
-			expectedOvertime:    hoursDuration(t, 1),
-			expectedExcusedTime: hoursDuration(t, 1),
+			expectedOvertime:    1 * time.Hour,
+			expectedExcusedTime: 1 * time.Hour,
 		},
 		"GivenSickLeaveAndOutsideOfficeHoursShifts_WhenWorkingHoursIsMoreThanDailyMax_ThenIgnoreSickLeaveCompletely": {
 			givenShifts: []AttendanceShift{
@@ -83,24 +83,24 @@ func TestDailySummary_CalculateOvertime(t *testing.T) {
 				newAttendanceShift(hours(t, weekday, "19:00"), hours(t, weekday, "20:00"), ReasonSickLeave),          // no overtime
 				newAttendanceShift(hours(t, weekday, "20:00"), hours(t, weekday, "22:00"), ReasonOutsideOfficeHours), // 3h overtime
 			},
-			expectedOvertime:    hoursDuration(t, 4),
-			expectedExcusedTime: hoursDuration(t, 1),
+			expectedOvertime:    4 * time.Hour,
+			expectedExcusedTime: 1 * time.Hour,
 		},
 		"GivenNoShifts_WhenNoLeavesEither_ThenReturnOneDayUndertime": {
 			givenShifts:      []AttendanceShift{},
-			expectedOvertime: hoursDuration(t, -8),
+			expectedOvertime: -8 * time.Hour,
 		},
 		"GivenDateInWeekend_WhenNoWorkingHours_ThenReturnNoOvertime": {
 			givenShifts:      []AttendanceShift{},
 			givenDate:        odoo.MustParseDate(weekendDay).Time,
-			expectedOvertime: hoursDuration(t, 0),
+			expectedOvertime: 0,
 		},
 		"GivenDateInWeekend_WhenWorkingHoursLogged_ThenReturnOvertime": {
 			givenShifts: []AttendanceShift{
 				newAttendanceShift(hours(t, weekday, "09:00"), hours(t, weekday, "10:00"), ""), // 1h overtime
 			},
 			givenDate:        odoo.MustParseDate(weekendDay).Time,
-			expectedOvertime: hoursDuration(t, 1),
+			expectedOvertime: 1 * time.Hour,
 		},
 		"GivenDateInWeekend_WhenExcusedHoursLogged_ThenIgnoreExcusedHours": {
 			givenShifts: []AttendanceShift{
@@ -108,7 +108,15 @@ func TestDailySummary_CalculateOvertime(t *testing.T) {
 				newAttendanceShift(hours(t, weekendDay, "09:00"), hours(t, weekendDay, "10:00"), ReasonPublicService), // no overtime
 			},
 			givenDate:        odoo.MustParseDate(weekendDay).Time,
-			expectedOvertime: hoursDuration(t, 1),
+			expectedOvertime: 1 * time.Hour,
+		},
+		"GivenInvalidShift_ThenIgnoreShift": {
+			givenShifts: []AttendanceShift{
+				newAttendanceShift(hours(t, weekday, "09:00"), hours(t, weekday, "16:00"), ""),
+				newAttendanceShift(hours(t, weekday, "16:00"), odoo.Date{}, ReasonSickLeave),
+			},
+			expectedOvertime:    -1 * time.Hour,
+			expectedExcusedTime: 0,
 		},
 	}
 	for name, tt := range tests {
@@ -291,7 +299,7 @@ func TestDailySummary_ValidateTimesheetEntries(t *testing.T) {
 			givenShifts: []AttendanceShift{
 				{Start: model.Attendance{DateTime: odoo.NewDate(2021, 01, 02, 8, 0, 0, time.UTC), Action: model.ActionSignIn}},
 			},
-			expectedError: "no sign_out detected for 2021-01-02 after 2021-01-02 08:00:00 +0000 UTC",
+			expectedError: "no sign_out detected for 2021-01-02 after 08:00:00",
 		},
 		"Single_SignOut_Error": {
 			givenShifts: []AttendanceShift{
@@ -306,7 +314,7 @@ func TestDailySummary_ValidateTimesheetEntries(t *testing.T) {
 					End:   model.Attendance{DateTime: odoo.NewDate(2021, 01, 02, 8, 0, 0, time.UTC), Action: model.ActionSignOut},
 				},
 			},
-			expectedError: "shift start and end times cannot be the same for 2021-01-02: 2021-01-02 08:00:00 +0000 UTC",
+			expectedError: "shift start and end times cannot be the same for 2021-01-02: 08:00:00",
 		},
 		"Multiple_SignOutMissing_Error": {
 			givenShifts: []AttendanceShift{
@@ -318,7 +326,7 @@ func TestDailySummary_ValidateTimesheetEntries(t *testing.T) {
 					Start: model.Attendance{DateTime: odoo.NewDate(2021, 01, 02, 11, 0, 0, time.UTC), Action: model.ActionSignIn},
 				},
 			},
-			expectedError: "no sign_out detected for 2021-01-02 after 2021-01-02 11:00:00 +0000 UTC",
+			expectedError: "no sign_out detected for 2021-01-02 after 11:00:00",
 		},
 		"Multiple_TotalDurationExceeds24h": {
 			givenShifts: []AttendanceShift{
@@ -340,7 +348,7 @@ func TestDailySummary_ValidateTimesheetEntries(t *testing.T) {
 					End:   model.Attendance{DateTime: odoo.NewDate(2021, 01, 02, 10, 0, 0, time.UTC), Action: model.ActionSignOut, Reason: &model.ActionReason{Name: ReasonSickLeave}},
 				},
 			},
-			expectedError: "the reasons for shift sign_in and sign_out have to be equal: start 2021-01-02 08:00:00 +0000 UTC (), end 2021-01-02 10:00:00 +0000 UTC (Sick / Medical Consultation)",
+			expectedError: "the reasons for shift sign_in and sign_out should be equal: start 08:00:00 (), end 10:00:00 (Sick / Medical Consultation)",
 		},
 	}
 	for name, tc := range tests {

--- a/pkg/timesheet/report.go
+++ b/pkg/timesheet/report.go
@@ -151,7 +151,6 @@ func (r *ReportBuilder) getTimeZone() *time.Location {
 }
 
 func (r *ReportBuilder) reduceAttendancesToShifts(attendances model.AttendanceList) []AttendanceShift {
-	attendances.SortByDate()
 	shifts := make([]AttendanceShift, 0)
 	tz := r.getTimeZone()
 	var tmpShift AttendanceShift

--- a/pkg/timesheet/validationerror.go
+++ b/pkg/timesheet/validationerror.go
@@ -1,6 +1,7 @@
 package timesheet
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -34,20 +35,24 @@ func (e *ValidationError) Unwrap() error {
 
 // Error returns a comma-separated list of dates that have a validation error.
 func (l *ValidationErrorList) Error() string {
+	if l == nil || len(l.Errors) == 0 {
+		return ""
+	}
 	dateList := make([]string, len(l.Errors))
 	for i, err := range l.Errors {
 		dateList[i] = err.Date.Format(odoo.DateFormat)
 	}
 	joinedList := strings.Join(dateList, ", ")
-	return fmt.Sprintf("validation invalid for date(s): [%s]", joinedList)
+	return fmt.Sprintf("Report invalid for date(s): [%s]", joinedList)
 }
 
-func AppendValidationError(list *ValidationErrorList, err *ValidationError) {
+// AppendValidationError appends an err to the given list, if err is of type ValidationError.
+func AppendValidationError(list *ValidationErrorList, err error) {
 	if list == nil && err == nil {
 		return
 	}
-	if list == nil {
-		*list = ValidationErrorList{}
+	var validationError *ValidationError
+	if errors.As(err, &validationError) {
+		list.Errors = append(list.Errors, validationError)
 	}
-	list.Errors = append(list.Errors, err)
 }

--- a/pkg/timesheet/validationerror.go
+++ b/pkg/timesheet/validationerror.go
@@ -1,0 +1,53 @@
+package timesheet
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/vshn/odootools/pkg/odoo"
+)
+
+type ValidationError struct {
+	Date time.Time
+	Err  error
+}
+
+type ValidationErrorList struct {
+	Errors []*ValidationError
+}
+
+func NewValidationError(forDate time.Time, err error) *ValidationError {
+	if err == nil {
+		return nil
+	}
+	return &ValidationError{Date: forDate, Err: err}
+}
+
+func (e *ValidationError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *ValidationError) Unwrap() error {
+	return e.Err
+}
+
+// Error returns a comma-separated list of dates that have a validation error.
+func (l *ValidationErrorList) Error() string {
+	dateList := make([]string, len(l.Errors))
+	for i, err := range l.Errors {
+		dateList[i] = err.Date.Format(odoo.DateFormat)
+	}
+	joinedList := strings.Join(dateList, ", ")
+	return fmt.Sprintf("validation invalid for date(s): [%s]", joinedList)
+}
+
+func AppendValidationError(list *ValidationErrorList, err *ValidationError) {
+	if list == nil && err == nil {
+		return
+	}
+	if list == nil {
+		*list = ValidationErrorList{}
+	}
+	list.Errors = append(list.Errors, err)
+}

--- a/pkg/timesheet/yearly_report.go
+++ b/pkg/timesheet/yearly_report.go
@@ -73,7 +73,7 @@ func (r *YearlyReportBuilder) CalculateYearlyReport() (YearlyReport, error) {
 		if firstDayOfMonth.Before(contractStartDate) {
 			start = contractStartDate
 		}
-		monthlyReportBuilder := NewReporter(r.attendances, r.leaves, r.employee, r.contracts)
+		monthlyReportBuilder := NewReporter(r.attendances.AddCurrentTimeAsSignOut(tz), r.leaves, r.employee, r.contracts)
 		monthlyReportBuilder.clock = r.clock
 		monthlyReport, err := monthlyReportBuilder.CalculateReport(start, lastDayOfMonth)
 		if err != nil {

--- a/pkg/web/controller/view.go
+++ b/pkg/web/controller/view.go
@@ -58,13 +58,14 @@ func (v BaseView) GetPreviousMonth(year, month int) (int, int) {
 func (v BaseView) FormatDailySummary(daily *timesheet.DailySummary) Values {
 	overtimeSummary := daily.CalculateOvertimeSummary()
 	basic := Values{
-		"Weekday":       daily.Date.Weekday(),
-		"Date":          daily.Date.Format(odoo.DateFormat),
-		"Workload":      daily.FTERatio * 100,
-		"ExcusedHours":  v.FormatDurationInHours(overtimeSummary.ExcusedTime()),
-		"WorkedHours":   v.FormatDurationInHours(overtimeSummary.WorkingTime()),
-		"OvertimeHours": v.FormatDurationInHours(overtimeSummary.Overtime()),
-		"LeaveType":     "",
+		"Weekday":         daily.Date.Weekday(),
+		"Date":            daily.Date.Format(odoo.DateFormat),
+		"Workload":        daily.FTERatio * 100,
+		"ExcusedHours":    v.FormatDurationInHours(overtimeSummary.ExcusedTime()),
+		"WorkedHours":     v.FormatDurationInHours(overtimeSummary.WorkingTime()),
+		"OvertimeHours":   v.FormatDurationInHours(overtimeSummary.Overtime()),
+		"LeaveType":       "",
+		"ValidationError": daily.ValidateTimesheetEntries(),
 	}
 	if daily.HasAbsences() {
 		basic["LeaveType"] = daily.Absences[0].Reason

--- a/pkg/web/employeereport/employeereport_view.go
+++ b/pkg/web/employeereport/employeereport_view.go
@@ -48,6 +48,10 @@ func (v *reportView) getValuesForReport(report timesheet.Report, previousPayslip
 	proposedBalanceCellText, proposedBalance := v.getProposedBalance(previousBalance, report.Summary.TotalOvertime)
 	nextBalanceCellText, nextBalance := v.getNextBalance(proposedBalance, nextPayslip)
 	overtimeBalanceEditPreview := v.getOvertimeBalanceEditPreview(nextPayslip, nextBalance)
+	validationErrorList := &timesheet.ValidationErrorList{}
+	for _, summary := range report.DailySummaries {
+		timesheet.AppendValidationError(validationErrorList, summary.ValidateTimesheetEntries())
+	}
 	return controller.Values{
 		"Name":                            report.Employee.Name,
 		"EmployeeID":                      report.Employee.ID,
@@ -65,6 +69,7 @@ func (v *reportView) getValuesForReport(report timesheet.Report, previousPayslip
 		"ProposedBalance":                 proposedBalanceCellText,
 		"OvertimeBalanceEditEnabled":      nextPayslip != nil,
 		"OvertimeBalanceEditPreviewValue": overtimeBalanceEditPreview,
+		"ValidationError":                 validationErrorList.Error(),
 	}
 }
 

--- a/pkg/web/overtimereport/monthlyreport_view.go
+++ b/pkg/web/overtimereport/monthlyreport_view.go
@@ -16,11 +16,16 @@ type monthlyReportView struct {
 
 func (v *monthlyReportView) GetValuesForMonthlyReport(report timesheet.BalanceReport) controller.Values {
 	formatted := make([]controller.Values, 0)
+	hasInvalidAttendances := ""
 	for _, summary := range report.Report.DailySummaries {
 		if summary.IsWeekend() && summary.CalculateOvertimeSummary().WorkingTime() == 0 {
 			continue
 		}
-		formatted = append(formatted, v.FormatDailySummary(summary))
+		values := v.FormatDailySummary(summary)
+		if values["ValidationError"] != nil {
+			hasInvalidAttendances = "Your timesheet contains errors."
+		}
+		formatted = append(formatted, values)
 	}
 	month, year := report.Report.From.Month(), report.Report.From.Year()
 	nextYear, nextMonth := v.GetNextMonth(year, int(month))
@@ -28,6 +33,7 @@ func (v *monthlyReportView) GetValuesForMonthlyReport(report timesheet.BalanceRe
 	linkFormat := "/report/%d/%d/%02d"
 	return controller.Values{
 		"Attendances": formatted,
+		"Warning":     hasInvalidAttendances,
 		"Summary":     v.formatMonthlySummary(report),
 		"Nav": controller.Values{
 			"LoggedIn":          true,

--- a/pkg/web/overtimereport/yearlyreport_view.go
+++ b/pkg/web/overtimereport/yearlyreport_view.go
@@ -41,6 +41,10 @@ func (v *yearlyReportView) formatMonthlySummaryForYearlyReport(s timesheet.Balan
 	if s.DefinitiveBalance != nil {
 		defBalance = v.FormatDurationInHours(*s.DefinitiveBalance)
 	}
+	validationErrorList := &timesheet.ValidationErrorList{}
+	for _, summary := range s.Report.DailySummaries {
+		timesheet.AppendValidationError(validationErrorList, summary.ValidateTimesheetEntries())
+	}
 	val := controller.Values{
 		"OvertimeHours":     v.FormatDurationInHours(s.Report.Summary.TotalOvertime),
 		"LeaveDays":         v.FormatFloat(s.Report.Summary.TotalLeave, 1),
@@ -49,6 +53,7 @@ func (v *yearlyReportView) formatMonthlySummaryForYearlyReport(s timesheet.Balan
 		"DefinitiveBalance": defBalance,
 		"DetailViewLink":    fmt.Sprintf("/report/%d/%d/%d", s.Report.Employee.ID, year, s.Report.From.Month()),
 		"Name":              fmt.Sprintf("%s %d", s.Report.From.Month(), year),
+		"ValidationError":   validationErrorList.Error(),
 	}
 	return val
 }

--- a/pkg/web/reportconfig/config_controller.go
+++ b/pkg/web/reportconfig/config_controller.go
@@ -80,11 +80,14 @@ func (c *ConfigController) parseInput(_ context.Context) error {
 func (c *ConfigController) searchEmployee(ctx context.Context) error {
 	if c.Input.SearchUserEnabled {
 		e, err := c.OdooClient.SearchEmployee(ctx, c.Input.SearchUser)
+		if err != nil {
+			return err
+		}
 		if e == nil {
 			return fmt.Errorf("no user matching '%s' found", c.Input.SearchUser)
 		}
 		c.Employee = *e
-		return err
+		return nil
 	}
 	if c.SessionData.Employee != nil {
 		c.Employee = *c.SessionData.Employee

--- a/pkg/web/reportconfig/config_controller.go
+++ b/pkg/web/reportconfig/config_controller.go
@@ -112,7 +112,6 @@ func (c *ConfigController) fetchAttendanceOfCurrentWeek(ctx context.Context) err
 	if err != nil {
 		return err
 	}
-	attendances.SortByDate()
 	c.Attendances = attendances.
 		FilterAttendanceBetweenDates(c.StartOfWeek, c.EndOfWeek).
 		AddCurrentTimeAsSignOut(c.User.TimeZone.Location)

--- a/templates/employeereport.html
+++ b/templates/employeereport.html
@@ -86,7 +86,10 @@
     <tbody>
     {{ range .Reports }}
     <tr>
-        <td><a href="{{ .ReportDirectLink }}">{{ .Name }}</a><br>Workload: {{ .Workload }}%<br>Location: {{ .Timezone }}</td>
+        <td>
+            <a href="{{ .ReportDirectLink }}">{{ .Name }}</a><br>Workload: {{ .Workload }}%<br>Location: {{ .Timezone }}
+            {{- with .ValidationError }}<br>⚠️ {{ . }}{{ end -}}
+        </td>
         <td>{{ .Leaves }}d</td>
         <td>{{ .ExcusedHours }}</td>
         <td>{{ .WorkedHours }}</td>

--- a/templates/overtimereport-monthly.html
+++ b/templates/overtimereport-monthly.html
@@ -1,9 +1,17 @@
 {{ define "main" }}
 <h1>Attendance for {{ .Username }}<small class="text-muted"> {{ .MonthDisplayName }}, {{ .TimezoneDisplayName }}</small></h1>
-<div class="float"></div>
-{{ with .Error }}
-<div class="alert alert-danger" role="alert">{{ . }}</div>
-{{ end }}
+<div class="float" id="alerts"></div>
+<div >
+    {{ with .Error }}
+    <div class="alert alert-danger" role="alert">{{ . }}</div>
+    {{ end }}
+    {{ with .Warning }}
+    <div class="alert alert-warning alert-dismissible" role="alert">
+        {{ . }}
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    {{ end }}
+</div>
 <p>
     <a href="{{ .Nav.PreviousMonthLink }}" class="btn btn-secondary">Previous</a>
     <a href="{{ .Nav.CurrentMonthLink }}" class="btn btn-primary">Current</a>
@@ -24,7 +32,7 @@
     <tbody>
     {{ range .Attendances }}
     <tr>
-        <td>{{ .Weekday }}</td>
+        <td>{{ .Weekday }}{{ with .ValidationError }}<br>⚠️ {{ . }}{{ end }}</td>
         <td>{{ .Date }}</td>
         <td>{{ .Workload }}%</td>
         <td>{{ .LeaveType }}</td>

--- a/templates/overtimereport-yearly.html
+++ b/templates/overtimereport-yearly.html
@@ -22,7 +22,7 @@
     <tbody>
     {{ range .MonthlyReports }}
     <tr>
-        <td><a href="{{ .DetailViewLink }}">{{ .Name }}</a></td>
+        <td><a href="{{ .DetailViewLink }}">{{ .Name }}</a>{{- with .ValidationError }} ⚠️{{- end }}</td>
         <td>{{ .LeaveDays }}d</td>
         <td>{{ .ExcusedHours }}</td>
         <td>{{ .WorkedHours }}</td>


### PR DESCRIPTION
## Summary

This feature will display errors when attendances are recorded wrongly. In the monthly report, a validation error will be displayed with a warning sign and the error message. In the yearly report, a warning icon is displayed next to the month's link if the month contains at least one violation.

In the employee report, the same icon is displayed in the row of the affected employee.

This PR changes how attendances are grouped into shifts. This also causes a few reports where overtime is calculated wrongly since it ignores invalid shifts.

Documentation is in a follow-up PR

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update the documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
