### PR TITLE
Fix bug that would ignore double sign_in in shifts

### DIFF
--- a/pkg/timesheet/report.go
+++ b/pkg/timesheet/report.go
@@ -171,10 +171,16 @@ func (r *ReportBuilder) addAttendancesToDailyShifts(attendances model.Attendance
 		} else {
 			shift = daily.Shifts[shiftCount-1]
 		}
-		//startDate := shift.Start.DateTime.Time
+		startDate := shift.Start.DateTime.Time
 		endDate := shift.End.DateTime.Time
 		if !endDate.IsZero() && (date.Equal(endDate) || date.After(endDate)) {
 			// new shift
+			shift = AttendanceShift{}
+			newShift = true
+		}
+		if !startDate.IsZero() && (attendance.Action == model.ActionSignIn) {
+			// start of shift already defined, which means we have 2 consecutive sign_ins.
+			// This is semantically invalid.
 			shift = AttendanceShift{}
 			newShift = true
 		}

--- a/pkg/timesheet/report_test.go
+++ b/pkg/timesheet/report_test.go
@@ -98,7 +98,9 @@ func TestReporter_addAbsencesToDailies(t *testing.T) {
 		"WhenSignOutMissing_ThenAddShiftWithZeroEndDate": {
 			givenTimeZone: zurichTZ,
 			givenAttendances: []model.Attendance{
-				{DateTime: odoo.MustParseDateTime("2021-02-03 19:00:00"), Action: model.ActionSignIn, Reason: &model.ActionReason{}},
+				{DateTime: odoo.MustParseDateTime("2021-02-03 08:00:00"), Action: model.ActionSignIn, Reason: &model.ActionReason{}},
+				{DateTime: odoo.MustParseDateTime("2021-02-03 10:00:00"), Action: model.ActionSignIn, Reason: &model.ActionReason{}},
+				{DateTime: odoo.MustParseDateTime("2021-02-03 16:00:00"), Action: model.ActionSignOut, Reason: &model.ActionReason{}},
 				{DateTime: odoo.MustParseDateTime("2021-02-03 23:00:00"), Action: model.ActionSignIn, Reason: &model.ActionReason{}},
 				{DateTime: odoo.MustParseDateTime("2021-02-04 00:00:00"), Action: model.ActionSignOut, Reason: &model.ActionReason{}},
 			},
@@ -112,11 +114,23 @@ func TestReporter_addAbsencesToDailies(t *testing.T) {
 					Shifts: []AttendanceShift{
 						{
 							Start: model.Attendance{
-								DateTime: odoo.NewDate(2021, 02, 03, 20, 0, 0, zurichTZ),
+								DateTime: odoo.NewDate(2021, 02, 03, 9, 0, 0, zurichTZ),
 								Action:   model.ActionSignIn,
 								Reason:   &model.ActionReason{},
 							},
 							End: model.Attendance{},
+						},
+						{
+							Start: model.Attendance{
+								DateTime: odoo.NewDate(2021, 02, 03, 11, 0, 0, zurichTZ),
+								Action:   model.ActionSignIn,
+								Reason:   &model.ActionReason{},
+							},
+							End: model.Attendance{
+								DateTime: odoo.NewDate(2021, 02, 03, 17, 0, 0, zurichTZ),
+								Action:   model.ActionSignOut,
+								Reason:   &model.ActionReason{},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
## Summary

Fixes an issue that if there are 2 consecutive sign_ins, the first sign_in would be ignored.
Now it can properly detect a validation error with double sign_in's.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update the documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
