### PR TITLE
Fix timezone in weekly report

### DIFF
--- a/pkg/web/reportconfig/config_controller.go
+++ b/pkg/web/reportconfig/config_controller.go
@@ -163,7 +163,7 @@ func (c *ConfigController) displayWarning(_ context.Context, err error) error {
 // getStartOfWeek returns the previously occurred Monday at midnight.
 // If t is already a Monday, it will be truncated to midnight the same day.
 func getStartOfWeek(t time.Time) time.Time {
-	t = t.Truncate(24 * time.Hour)
+	t = time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
 	if t.Weekday() == time.Sunday { // go treats Sunday as the first day of the week
 		return t.AddDate(0, 0, -6)
 	}


### PR DESCRIPTION

## Summary

Fixes an issue where leaves would not show up in the weekly report, but only in monthly or yearly report.
This is due to timezone issue (again...)

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update the documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
