### PR TITLE
Fix timezone in weekly report

### DIFF
--- a/pkg/odoo/date.go
+++ b/pkg/odoo/date.go
@@ -67,6 +67,11 @@ func LocalizeTime(tm time.Time, loc *time.Location) time.Time {
 	return time.Date(tm.Year(), tm.Month(), tm.Day(), tm.Hour(), tm.Minute(), tm.Second(), tm.Nanosecond(), loc)
 }
 
+// Midnight returns a new time object in midnight (most recently past).
+func Midnight(tm time.Time) time.Time {
+	return time.Date(tm.Year(), tm.Month(), tm.Day(), 0, 0, 0, 0, tm.Location())
+}
+
 // MustParseDateTime parses the given value in DateTimeFormat or panics if it fails.
 func MustParseDateTime(value string) Date {
 	tm, err := ParseDateTime(value)

--- a/pkg/timesheet/report.go
+++ b/pkg/timesheet/report.go
@@ -218,7 +218,7 @@ func (r *ReportBuilder) reduceLeavesToBlocks(leaves []model.Leave) []AbsenceBloc
 			from := leave.DateFrom
 			blocks = append(blocks, AbsenceBlock{
 				Reason: leave.Type.String(),
-				Date:   time.Date(from.Year(), from.Month(), from.Day(), 0, 0, 0, 0, from.Location()),
+				Date:   odoo.Midnight(from.Time),
 			})
 		}
 	}
@@ -275,7 +275,7 @@ func (r *ReportBuilder) filterLeavesInTimeRange() []model.Leave {
 		for _, split := range splits {
 			tz := r.getTimeZone()
 			from := split.DateFrom
-			date := time.Date(from.Year(), from.Month(), from.Day(), 0, 0, 0, 0, tz)
+			date := odoo.Midnight(from.In(tz))
 			if odoo.IsWithinTimeRange(date, r.from, r.to) && date.Weekday() != time.Sunday && date.Weekday() != time.Saturday {
 				split.DateFrom.Time = odoo.LocalizeTime(split.DateFrom.Time, tz)
 				split.DateTo.Time = odoo.LocalizeTime(split.DateTo.Time, tz)

--- a/pkg/web/reportconfig/config_controller.go
+++ b/pkg/web/reportconfig/config_controller.go
@@ -128,8 +128,8 @@ func (c *ConfigController) fetchUser(ctx context.Context) error {
 	}
 	tz := user.TimeZone.LocationOrDefault(timesheet.DefaultTimeZone)
 	c.User = user
-	c.StartOfWeek = c.StartOfWeek.In(tz)
-	c.EndOfWeek = c.EndOfWeek.In(tz)
+	c.StartOfWeek = odoo.Midnight(c.StartOfWeek.In(tz))
+	c.EndOfWeek = odoo.Midnight(c.EndOfWeek.In(tz))
 	return nil
 }
 
@@ -163,7 +163,7 @@ func (c *ConfigController) displayWarning(_ context.Context, err error) error {
 // getStartOfWeek returns the previously occurred Monday at midnight.
 // If t is already a Monday, it will be truncated to midnight the same day.
 func getStartOfWeek(t time.Time) time.Time {
-	t = time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+	t = odoo.Midnight(t)
 	if t.Weekday() == time.Sunday { // go treats Sunday as the first day of the week
 		return t.AddDate(0, 0, -6)
 	}


### PR DESCRIPTION
## Summary

Fixes an issue where leaves would not show up in the weekly report, but only in monthly or yearly report.
This is due to timezone issue (again...)

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update the documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
