### PR TITLE
Fix leave calculation if leave was on Monday in vancouver

### DIFF
--- a/pkg/timesheet/report.go
+++ b/pkg/timesheet/report.go
@@ -276,7 +276,7 @@ func (r *ReportBuilder) filterLeavesInTimeRange() []model.Leave {
 			tz := r.getTimeZone()
 			from := split.DateFrom
 			date := odoo.Midnight(from.In(tz))
-			if odoo.IsWithinTimeRange(date, r.from, r.to) && date.Weekday() != time.Sunday && date.Weekday() != time.Saturday {
+			if odoo.IsWithinTimeRange(date, r.from, r.to) {
 				split.DateFrom.Time = odoo.LocalizeTime(split.DateFrom.Time, tz)
 				split.DateTo.Time = odoo.LocalizeTime(split.DateTo.Time, tz)
 				filteredLeaves = append(filteredLeaves, split)


### PR DESCRIPTION
## Summary

Fixes an issue where a leave spanning a weekend would not be recognized on a Monday if in different timezone

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update the documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
