### PR TITLE
Remove radio check for HR manager

### DIFF
--- a/pkg/web/reportconfig/config_request.go
+++ b/pkg/web/reportconfig/config_request.go
@@ -36,9 +36,9 @@ func (i *ReportRequest) FromRequest(e echo.Context) error {
 	if err := e.Bind(i); err != nil {
 		return err
 	}
-	i.SearchUserEnabled = e.FormValue("userscope") == "user-foreign-radio"
 	i.EmployeeReportEnabled = e.FormValue("employeeReport") == "true"
 	i.SearchUser = html.EscapeString(i.SearchUser)
+	i.SearchUserEnabled = i.SearchUser != ""
 
 	if i.Month == 0 && i.Year == 0 {
 		// this is kinda invalid input. Maybe created via curl or so.

--- a/templates/createreport.html
+++ b/templates/createreport.html
@@ -75,21 +75,9 @@
         <input type="number" class="form-control" name="month" id="month" min="1" max="12" value="1">
     </div>
     {{- if .Roles.HRManager }}
-    <div class="mb-3 form-check">
-        <input class="form-check-input" type="radio" id="userselfradio" name="userscope" value="user-self-radio"
-               checked>
-        <label class="form-check-label" for="userselfradio">
-            For myself
-        </label>
-    </div>
-    <div class="mb-3 form-check form-check-inline">
-        <input class="form-check-input" type="radio" id="userforeignradio" name="userscope" value="user-foreign-radio">
-        <label class="form-check-label" for="userforeignradio">
-            For someone else
-        </label>
-        <span>
-            <input class="form-control" type="text" name="username" id="username" placeholder="Search Username">
-        </span>
+    <div class="mb-3">
+        <label for="username" class="form-label">For someone else</label>
+        <input type="text" class="form-control" name="username" id="username" placeholder="Search Username">
     </div>
     {{- end }}
     <div class="mb-3">


### PR DESCRIPTION
## Summary

The radio check is unnecessary. 
We can just check if the username input has a value.

This cleans up the `/report` view a bit.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update the documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
