### PR TITLE
Limit the max width for very wide screens

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -13,7 +13,7 @@
 <style>
     @media (min-width: 2000px) {
     .container{
-        max-width: 2000px;
+        max-width: 1320px;
     }
 }
 </style>


### PR DESCRIPTION
## Summary

On very large screens the table gets widened to a point where it's becoming less readable.
This PR limits the max width of the main container.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update the documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
